### PR TITLE
Make only one namespace: flit.  Remove "using namespace ..."

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,16 +178,16 @@ To prevent tests from running, just remove them from the _tests_ directory.
 
 #### Adding tests ####
 
-All litmus tests that are included in general execution are located in the _FLiT/src/tests_ directory. For a test to be included in a run it only need be present in this directory. Tests must be in a templated C++ class which extends `QFPTest::TestBase<T>`.
+All litmus tests that are included in general execution are located in the _FLiT/src/tests_ directory. For a test to be included in a run it only need be present in this directory. Tests must be in a templated C++ class which extends `flit::TestBase<T>`.
 
 ##getInputsPerRun
 This function returns the number of arguments the code under tests uses.
 
 ##getDefaultInput
-This function returns a `QFPTest::TestInput`, which is a vector like object whose `.vals` field holds a list of inputs. Note that more than one set of inputs may be placed in this field.
+This function returns a `flit::TestInput`, which is a vector like object whose `.vals` field holds a list of inputs. Note that more than one set of inputs may be placed in this field.
 
 ##run_impl
-This function is the actual code under test. The argument is a `QFPTest::TestInput` with length of the `.vals` field equal to the number of inputs requested per run. The return is a vector of two values representing the score of the test. This does not need to represent 'good' or 'bad' results, as the score is used to classify different compilations.
+This function is the actual code under test. The argument is a `flit::TestInput` with length of the `.vals` field equal to the number of inputs requested per run. The return is a vector of two values representing the score of the test. This does not need to represent 'good' or 'bad' results, as the score is used to classify different compilations.
 
 ##REGISTER_TEST
 Just as it sounds, this function is used to register the test in the framework. It's argument is the class created for the test.
@@ -197,84 +197,6 @@ The main setup for CUDA tests is the same, with the exception that the `run_impl
 
 #Integrating into the test framework
 The test cpp file must be placed in `QFP/qfpc/tests` for it to be included in subsequent runs. No other changes are required.
-
-#Starting code
-This is a simple source file to start your own tests.
-
-```
-#include "test_base.hpp" 
-#include "QFPHelpers.hpp"
-#include "CUHelpers.hpp"
-
-// These functions are not needed, but it is nice to break out the core computation being done
-template <typename T>
-DEVICE
-T 
-my_cuda_test_core(const T input_1) // Number of arguments can be changed
-{
-    return input_1; // Cuda test code
-}
-
-template <typename T>
-T 
-my_cpp_test_core(const T input_1) // Number of arguments can be changed
-{
-    return input_1; // Cpp test code
-}
-
-
-template <typename T>
-GLOBAL
-void 
-my_cuda_kern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-    using namespace CUHelpers;
-#ifdef __CUDA__
-    auto idx = blockIdx.x * blockDim.x + threadIdx.x;
-#else
-    auto idx = 0;
-#endif
-    T input_1 = tiList[idx].vals[0]; // Extract arguments from vals
-
-    // Loops or other structures can be used here such as in TrianglePSylv.cpp  
-    double score = my_cuda_test_core(input);
-
-    results[idx].s1 = score;
-    results[idx].s2 = 0.0;
-}
-
-template <typename T>
-class MyTest: public QFPTest::TestBase<T> {
-public:
-    MyTest(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
-
-    // This must be changed to match the number of arguments used in the test code
-    virtual size_t getInputsPerRun() { return 1; } 
-
-    virtual QFPTest::TestInput<T> getDefaultInput() {
-        QFPTest::TestInput<T> ti;
-        ti.vals = { 6.0 };
-        return ti;
-    }
-
-protected:
-    virtual
-    QFPTest::KernelFunction<T>* getKernel() {return my_cuda_kern; }
-    virtual
-    QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
-        T input_1 = ti.vals[0]; // Extract arguments from vals
-        
-        // Loops or other structures can be used here such as in TrianglePSylv.cpp  
-        double score = my_cpp_kern(input_1);
-
-        return {score, 0.0};
-    }
-
-protected:
-    using QFPTest::TestBase<T>::id;
-};
-
-REGISTER_TYPE(MyTest)
-```
 
 ### Choosing compilers and flags ###
 

--- a/documentation/AddingLitmusTests.md
+++ b/documentation/AddingLitmusTests.md
@@ -1,15 +1,15 @@
 #Adding Your Own Litmus Tests to FLiT
 
-All litmus tests that are included in general execution are located in the `QFP/qfpc/tests` directory. For a test to be included in a run it only need be present in this directory. Tests must be in a templated C++ class which extends `QFPTest::TestBase<T>`.
+All litmus tests that are included in general execution are located in the `QFP/qfpc/tests` directory. For a test to be included in a run it only need be present in this directory. Tests must be in a templated C++ class which extends `flit::TestBase<T>`.
 
 ##getInputsPerRun
 This function returns the number of arguments the code under tests uses.
 
 ##getDefaultInput
-This function returns a `QFPTest::TestInput`, which is a vector like object whose `.vals` field holds a list of inputs. Note that more than one set of inputs may be placed in this field.
+This function returns a `flit::TestInput`, which is a vector like object whose `.vals` field holds a list of inputs. Note that more than one set of inputs may be placed in this field.
 
 ##run_impl
-This function is the actual code under test. The argument is a `QFPTest::TestInput` with length of the `.vals` field equal to the number of inputs requested per run. The return is a vector of two values representing the score of the test. This does not need to represent 'good' or 'bad' results, as the score is used to classify different compilations.
+This function is the actual code under test. The argument is a `flit::TestInput` with length of the `.vals` field equal to the number of inputs requested per run. The return is a vector of two values representing the score of the test. This does not need to represent 'good' or 'bad' results, as the score is used to classify different compilations.
 
 ##REGISTER_TEST
 Just as it sounds, this function is used to register the test in the framework. It's argument is the class created for the test.
@@ -48,8 +48,7 @@ my_cpp_test_core(const T input_1) // Number of arguments can be changed
 template <typename T>
 GLOBAL
 void 
-my_cuda_kern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-    using namespace CUHelpers;
+my_cuda_kern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
     auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
@@ -65,24 +64,24 @@ my_cuda_kern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* 
 }
 
 template <typename T>
-class MyTest: public QFPTest::TestBase<T> {
+class MyTest: public flit::TestBase<T> {
 public:
-    MyTest(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+    MyTest(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
     // This must be changed to match the number of arguments used in the test code
     virtual size_t getInputsPerRun() { return 1; } 
 
-    virtual QFPTest::TestInput<T> getDefaultInput() {
-        QFPTest::TestInput<T> ti;
+    virtual flit::TestInput<T> getDefaultInput() {
+        flit::TestInput<T> ti;
         ti.vals = { 6.0 };
         return ti;
     }
 
 protected:
     virtual
-    QFPTest::KernelFunction<T>* getKernel() {return my_cuda_kern; }
+    flit::KernelFunction<T>* getKernel() {return my_cuda_kern; }
     virtual
-    QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+    flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
         T input_1 = ti.vals[0]; // Extract arguments from vals
         
         // Loops or other structures can be used here such as in TrianglePSylv.cpp  
@@ -92,7 +91,7 @@ protected:
     }
 
 protected:
-    using QFPTest::TestBase<T>::id;
+    using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(MyTest)

--- a/gensrc/testcase.py
+++ b/gensrc/testcase.py
@@ -11,16 +11,12 @@ import os
 # - cu_vars_initialize: initialize scope variables for the test in CUDA using tiList[idx].vals
 # - func_body: test body that is shared between cuda and non-cuda.  Populate score1 and score2
 template_string = '''
-#include "TestBase.hpp"
-#include "QFPHelpers.hpp"
-#include "CUHelpers.hpp"
-
-using namespace CUHelpers;
+#include "flit.h"
 
 template <typename T>
 GLOBAL
 void
-{name}Kernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results) {{
+{name}Kernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results) {{
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
@@ -40,14 +36,14 @@ void
 }}
 
 template <typename T>
-class {name} : public QFPTest::TestBase<T> {{
+class {name} : public flit::TestBase<T> {{
 public:
   {name}(std::string id)
-    : QFPTest::TestBase<T>(std::move(id)) {{}}
+    : flit::TestBase<T>(std::move(id)) {{}}
 
   virtual size_t getInputsPerRun() {{ return {input_count}; }}
-  virtual QFPTest::TestInput<T> getDefaultInput() {{
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {{
+    flit::TestInput<T> ti;
 
     {default_input}
 
@@ -55,33 +51,33 @@ public:
   }}
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() {{
+  virtual flit::KernelFunction<T>* getKernel() {{
     return {name}Kernel;
   }}
 
   virtual
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {{
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {{
     T score1 = 0.0;
     T score2 = 0.0;
 
-    QFPHelpers::info_stream << id << ": Starting test with parameters" << std::endl;
+    flit::info_stream << id << ": Starting test with parameters" << std::endl;
     for (T val : ti.vals) {{
-      QFPHelpers::info_stream << id << ":   " << val << std::endl;
+      flit::info_stream << id << ":   " << val << std::endl;
     }}
 
     {vars_initialize}
 
-    QFPHelpers::info_stream << id << ": After initializing variables" << std::endl;
+    flit::info_stream << id << ": After initializing variables" << std::endl;
 
     {func_body}
 
-    QFPHelpers::info_stream << id << ": Ending test with values (" << score1 << ", " << score2 << ")" << std::endl;
+    flit::info_stream << id << ": Ending test with values (" << score1 << ", " << score2 << ")" << std::endl;
 
-    return {{score1, score2}};
+    return {{std::pair<long double, long double>(score1, score2), 0}};
   }}
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 }};
 
 REGISTER_TYPE({name})

--- a/inputGen/groundtruth.cpp
+++ b/inputGen/groundtruth.cpp
@@ -9,10 +9,10 @@ namespace {
   runGroundtruth_impl(std::string testName,
                       std::function<T()> randGen)
   {
-    using QFPTest::TestInput;
-    using QFPHelpers::Vector;
+    using flit::TestInput;
+    using flit::Vector;
 
-    auto test = QFPTest::getTests()[testName]->get<T>();
+    auto test = flit::getTests()[testName]->get<T>();
     TestInput<T> input = test->getDefaultInput();
     input.vals = Vector<T>(test->getInputsPerRun(), randGen).getData();
     auto scores = test->run(input);
@@ -20,7 +20,7 @@ namespace {
     // Return only the first score.  Ignore the key
     return { input.vals, std::get<0>(scores.begin()->second) };
   }
-}
+} // end of unnamed namespace
 
 TruthType<float>
 runGroundtruth(const std::string &testName, std::function<float()> randGen) {

--- a/inputGen/helper.cpp
+++ b/inputGen/helper.cpp
@@ -21,7 +21,7 @@ void printTestVal(const std::string &funcName, float val) {
   FmtRestore restorer(std::cout);
   Q_UNUSED(restorer);
 
-  auto intval = QFPHelpers::as_int(val);
+  auto intval = flit::as_int(val);
   std::cout << funcName << ":     0x"
             << std::hex << std::setw(8) << std::setfill('0') << intval
             << "  "
@@ -33,7 +33,7 @@ void printTestVal(const std::string &funcName, double val) {
   FmtRestore restorer(std::cout);
   Q_UNUSED(restorer);
 
-  auto intval = QFPHelpers::as_int(val);
+  auto intval = flit::as_int(val);
   std::cout << funcName << ":     0x"
             << std::hex << std::setw(16) << std::setfill('0') << intval
             << "  "
@@ -45,7 +45,7 @@ void printTestVal(const std::string &funcName, long double val) {
   FmtRestore restorer(std::cout);
   Q_UNUSED(restorer);
 
-  auto intval = QFPHelpers::as_int(val);
+  auto intval = flit::as_int(val);
   uint64_t lhalf = static_cast<uint64_t>((intval >> 64)) & 0xFFFFL;
   uint64_t rhalf = static_cast<uint64_t>(intval);
 
@@ -64,7 +64,7 @@ namespace {
     return seedGenerator();
   }
 
-}
+} // end of unnamed namespace
 
 uint32_t randGenerator32() {
   static auto seed = generateSeed();

--- a/inputGen/helper.h
+++ b/inputGen/helper.h
@@ -32,7 +32,7 @@ template<> inline
 float generateFloatBits<float>(RandType type) {
   switch (type) {
     case RandType::UniformFP:
-      return QFPHelpers::as_float(randGenerator32());
+      return flit::as_float(randGenerator32());
     case RandType::UniformReals:
       return randRealFloatGenerator();
     default:
@@ -44,7 +44,7 @@ template<> inline
 double generateFloatBits<double>(RandType type) {
   switch (type) {
     case RandType::UniformFP:
-      return QFPHelpers::as_float(randGenerator64());
+      return flit::as_float(randGenerator64());
     case RandType::UniformReals:
       return randRealDoubleGenerator();
     default:
@@ -56,7 +56,7 @@ template<> inline
 long double generateFloatBits<long double>(RandType type) {
   switch (type) {
     case RandType::UniformFP:
-      return QFPHelpers::as_float(randGenerator128());
+      return flit::as_float(randGenerator128());
     case RandType::UniformReals:
       return randRealLongDoubleGenerator();
     default:

--- a/inputGen/main.cpp
+++ b/inputGen/main.cpp
@@ -93,7 +93,7 @@ void runAllPrecisions(const std::string testName, uint divergentCount,
 
 std::vector<std::string> getTestNames() {
   std::vector<std::string> retval;
-  for (auto entry : QFPTest::getTests()) {
+  for (auto entry : flit::getTests()) {
     retval.push_back(entry.first);
   }
   return retval;

--- a/inputGen/testbed.cpp
+++ b/inputGen/testbed.cpp
@@ -11,10 +11,10 @@ namespace {
   runTestbed_impl(const std::string &testName,
                   const std::vector<T> &inputvals)
   {
-    using QFPTest::TestInput;
-    using QFPHelpers::Vector;
+    using flit::TestInput;
+    using flit::Vector;
 
-    auto test = QFPTest::getTests()[testName]->get<T>();
+    auto test = flit::getTests()[testName]->get<T>();
     TestInput<T> input = test->getDefaultInput();
     input.vals = inputvals;
     auto scores = test->run(input);
@@ -22,7 +22,7 @@ namespace {
     // Return only the first score.  Ignore the key
     return std::get<0>(scores.begin()->second);
   }
-}
+} // end of unnamed namespace
 
 
 long double

--- a/litmus-tests/disabled/SimpleCHull.cpp
+++ b/litmus-tests/disabled/SimpleCHull.cpp
@@ -2,28 +2,25 @@
 #include "QFPHelpers.hpp"
 
 //#define SCH_LIB
-#define WFT float
 #include "simple_convex_hull.h"
 
 #include <cmath>
 #include <cstdio>
 #include <typeinfo>
 
-using namespace CUHelpers;
-
 template <typename T>
-class SimpleCHull: public QFPTest::TestBase<T> {
+class SimpleCHull: public flit::TestBase<T> {
 public:
-  SimpleCHull(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  SimpleCHull(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun(){ return 0; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){ return {}; }
+  virtual flit::TestInput<T> getDefaultInput(){ return {}; }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     Q_UNUSED(ti);
     CHullEdges.clear();
     PointList.clear();
@@ -34,7 +31,7 @@ protected:
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(SimpleCHull)

--- a/litmus-tests/disabled/simple_convex_hull.cpp
+++ b/litmus-tests/disabled/simple_convex_hull.cpp
@@ -11,8 +11,6 @@ extern "C" {
 
 #include "simple_convex_hull.h"
 
-using namespace std;
-
 #ifndef IFT
 #define IFT float
 #endif
@@ -21,7 +19,7 @@ using namespace std;
 #if defined(__CUDA__) || defined(__aarch64__)
 #define OFT double
 #else
-#define OFT __float128
+#define OFT long double
 #endif
 #endif
 
@@ -33,14 +31,14 @@ int CANO_FORM = 0;
 int SAMPLE_PHASE = 0;
 int VERIFY_METHOD = 0;
 
-vector<Point> PointList;
-vector<Edge> CHullEdges;
+std::vector<Point> PointList;
+std::vector<Edge> CHullEdges;
 
 size_t getEdgeCount() {
   return CHullEdges.size();
 }
 
-vector<PrimitiveCall> Decisions;
+std::vector<PrimitiveCall> Decisions;
 
 /*
   Some variables for deciding the "localness"
@@ -62,12 +60,12 @@ bool IsOnPQ (Point p, Point q, Point r) {
   else return false;
 }
 
-void Canonical_Unordered_Points (vector<Point>& pv, int cano_selection) {
+void Canonical_Unordered_Points (std::vector<Point>& pv, int cano_selection) {
   assert(1 <= cano_selection && cano_selection <= 2);
 
   if (pv.size() == 0 || pv.size() == 1) return;
 
-  vector<Point> temp_pv;
+  std::vector<Point> temp_pv;
   int *new_inds = (int*) malloc(sizeof(int) * pv.size());
 
   for (size_t i = 0 ; i < pv.size() ; i++)
@@ -108,14 +106,14 @@ void Canonical_Unordered_Points (vector<Point>& pv, int cano_selection) {
 }
 
 void PrintPoint(Point p) {
-  cout << "[" << p.id << "](" << (long double) p.x << ", " << (long double) p.y << ")";
+  std::cout << "[" << p.id << "](" << (long double) p.x << ", " << (long double) p.y << ")";
 }
 
-void PrintPV (vector<Point> pv) {
-  vector<Point>::iterator pi = pv.begin();
+void PrintPV (std::vector<Point> pv) {
+  std::vector<Point>::iterator pi = pv.begin();
   for ( ; pi != pv.end() ; pi++) {
     PrintPoint((*pi));
-    cout << endl;
+    std::cout << std::endl;
   }
 }
 
@@ -222,11 +220,11 @@ void GiftWrappingComputeConvexhull (FILE *outfile) {
   }
 
 #ifdef __VERBOSE
-  vector<Edge>::iterator ei;
+  std::vector<Edge>::iterator ei;
   for (ei = CHullEdges.begin() ; ei != CHullEdges.end() ; ei++) {
-    cout << "CHulldge: " << endl;
-    PrintPoint(ei->first); cout << endl;
-    PrintPoint(ei->second); cout << endl;
+    std::cout << "CHulldge: " << std::endl;
+    PrintPoint(ei->first); std::cout << std::endl;
+    PrintPoint(ei->second); std::cout << std::endl;
   }
 #endif
 }
@@ -284,7 +282,7 @@ void VerifyHull(FILE *outfile) {
 }
 
 OFT CheckConsistency () {
-  cout << "Decision size: " << Decisions.size() << endl;
+  std::cout << "Decision size: " << Decisions.size() << std::endl;
   for (size_t i = 0 ; i < Decisions.size() ; i++) {
     PrimitiveCall LTxyz;
     if ( Decisions[i].result ) {
@@ -306,8 +304,8 @@ OFT CheckConsistency () {
 	  LTxyz.idr == Decisions[j].idr &&
 	  Decisions[j].result == false) {
 #ifdef __VERBOSE
-	cout << "Violation of cyclic symmetry: " << endl;
-	cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of cyclic symmetry: " << std::endl;
+	std::cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
       if (LTxyz.idp == Decisions[j].idq &&
@@ -315,8 +313,8 @@ OFT CheckConsistency () {
 	  LTxyz.idr == Decisions[j].idp &&
 	  Decisions[j].result == false) {
 #ifdef __VERBOSE
-	cout << "Violation of cyclic symmetry: " << endl;
-	cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of cyclic symmetry: " << std::endl;
+	std::cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
       if (LTxyz.idp == Decisions[j].idr &&
@@ -324,8 +322,8 @@ OFT CheckConsistency () {
 	  LTxyz.idr == Decisions[j].idq &&
 	  Decisions[j].result == false) {
 #ifdef __VERBOSE
-	cout << "Violation of cyclic symmetry: " << endl;
-	cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of cyclic symmetry: " << std::endl;
+	std::cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
 
@@ -335,8 +333,8 @@ OFT CheckConsistency () {
 	  LTxyz.idr == Decisions[j].idq &&
 	  Decisions[j].result == true) {
 #ifdef __VERBOSE
-	cout << "Violation of antisymmetry: " << endl;
-	cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of antisymmetry: " << std::endl;
+	std::cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
       if (LTxyz.idp == Decisions[j].idr &&
@@ -344,8 +342,8 @@ OFT CheckConsistency () {
 	  LTxyz.idr == Decisions[j].idp &&
 	  Decisions[j].result == true) {
 #ifdef __VERBOSE
-	cout << "Violation of antisymmetry: " << endl;
-	cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of antisymmetry: " << std::endl;
+	std::cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
       if (LTxyz.idp == Decisions[j].idq &&
@@ -353,8 +351,8 @@ OFT CheckConsistency () {
 	  LTxyz.idr == Decisions[j].idr &&
 	  Decisions[j].result == true) {
 #ifdef __VERBOSE
-	cout << "Violation of antisymmetry: " << endl;
-	cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of antisymmetry: " << std::endl;
+	std::cout << LTxyz.idp << " " << LTxyz.idq << " " << LTxyz.idr << " " << LTxyz.result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
 
@@ -365,8 +363,8 @@ OFT CheckConsistency () {
 	  Decisions[i].result == false &&
 	  Decisions[j].result == false) {
 #ifdef __VERBOSE
-	cout << "Violation of nondegeneracy: " << endl;
-	cout << Decisions[i].idp << " " << Decisions[i].idq << " " << Decisions[i].idr << " " << Decisions[i].result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of nondegeneracy: " << std::endl;
+	std::cout << Decisions[i].idp << " " << Decisions[i].idq << " " << Decisions[i].idr << " " << Decisions[i].result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
       if (Decisions[i].idp == Decisions[j].idr &&
@@ -375,8 +373,8 @@ OFT CheckConsistency () {
 	  Decisions[i].result == false &&
 	  Decisions[j].result == false) {
 #ifdef __VERBOSE
-	cout << "Violation of nondegeneracy: " << endl;
-	cout << Decisions[i].idp << " " << Decisions[i].idq << " " << Decisions[i].idr << " " << Decisions[i].result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of nondegeneracy: " << std::endl;
+	std::cout << Decisions[i].idp << " " << Decisions[i].idq << " " << Decisions[i].idr << " " << Decisions[i].result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
       if (Decisions[i].idp == Decisions[j].idq &&
@@ -385,8 +383,8 @@ OFT CheckConsistency () {
 	  Decisions[i].result == false &&
 	  Decisions[j].result == false) {
 #ifdef __VERBOSE
-	cout << "Violation of nondegeneracy: " << endl;
-	cout << Decisions[i].idp << " " << Decisions[i].idq << " " << Decisions[i].idr << " " << Decisions[i].result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << endl;
+	std::cout << "Violation of nondegeneracy: " << std::endl;
+	std::cout << Decisions[i].idp << " " << Decisions[i].idq << " " << Decisions[i].idr << " " << Decisions[i].result << "  vs  " << Decisions[j].idp << " " << Decisions[j].idq << " " << Decisions[j].idr << " " << Decisions[j].result << std::endl;
 #endif
 	return -1; }
     }
@@ -394,64 +392,3 @@ OFT CheckConsistency () {
 
   return 1;
 }
-
-#ifndef SCH_LIB
-
-int main (int argc, char *argv[]) {
-  assert(argc == 7);
-
-  CHMETHOD = atoi(argv[1]);
-  assert(CHMETHOD == 0 ||
-	 CHMETHOD == 1);
-
-  CANO_FORM = atoi(argv[2]);
-  // assert(0 <= CANO_FORM && CANO_FORM <= 2);
-  assert(CANO_FORM == 0);
-
-  SAMPLE_PHASE = atoi(argv[3]);
-  assert(0 <= SAMPLE_PHASE && SAMPLE_PHASE <= 1);
-
-  VERIFY_METHOD = atoi(argv[4]);
-  assert(0 <= VERIFY_METHOD && VERIFY_METHOD <= 1);
-
-  FILE *infile = s3fpGetInFile(argc, argv);
-  FILE *outfile = s3fpGetOutFile(argc, argv);
-
-  ReadInputs(infile);
-
-  switch (CHMETHOD) {
-  case 0:
-    SimpleComputeConvexhull(); //outfile);
-    break;
-  case 1:
-    GiftWrappingComputeConvexhull(outfile);
-    break;
-  default:
-    assert(false && "Error: Invalid convex hull method");
-    break;
-  }
-
-  VerifyHull(outfile);
-
-  if (VERIFY_METHOD == 0 ||
-      VERIFY_METHOD == 1) {
-    if (RAISE_ASSERTION == false) {
-      OFT odata = 1;
-      fwrite(&odata, sizeof(OFT), 1, outfile);
-      fwrite(&odata, sizeof(OFT), 1, outfile);
-
-      fwrite(&odata, sizeof(OFT), 1, outfile);
-      //printf("hull edge count: %u\n", CHullEdges.size());
-      odata = CHullEdges.size();
-      fwrite(&odata, sizeof(OFT), 1, outfile);
-    }
-  }
-  else assert(false && "Error: Invalid verification method");
-
-  fclose(infile);
-  fclose(outfile);
-
-  return 0;
-}
-
-#endif // #ifndef SCH_LIB

--- a/litmus-tests/disabled/simple_convex_hull.h
+++ b/litmus-tests/disabled/simple_convex_hull.h
@@ -20,10 +20,11 @@ extern "C" {
 #if defined(__CUDA__) || defined(__aarch64__)
 #define OFT double
 #else
-#define OFT __float128
+#define OFT long double
 #endif
 #endif
 
+#define WFT float
 
 struct Point {
   long id;
@@ -266,9 +267,9 @@ void SimpleComputeConvexhull () { // (FILE *outfile) {
 #ifdef __VERBOSE
   std::vector<Edge>::iterator ei;
   for (ei = CHullEdges.begin() ; ei != CHullEdges.end() ; ei++) {
-    cout << "CHulldge: " << endl;
-    PrintPoint(ei->first); cout << endl;
-    PrintPoint(ei->second); cout << endl;
+    std::cout << "CHulldge: " << std::endl;
+    PrintPoint(ei->first); std::cout << std::endl;
+    PrintPoint(ei->second); std::cout << std::endl;
   }
 #endif
 }

--- a/litmus-tests/tests/DistributivityOfMultiplication.cpp
+++ b/litmus-tests/tests/DistributivityOfMultiplication.cpp
@@ -12,12 +12,10 @@
 #include "thrust/tuple.h"
 #endif
 
-using namespace CUHelpers;
-
 template <typename T>
 GLOBAL
 void
-DistOfMultKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
+DistOfMultKernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
@@ -35,21 +33,21 @@ DistOfMultKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultEleme
 }
 
 template <typename T>
-class DistributivityOfMultiplication : public QFPTest::TestBase<T> {
+class DistributivityOfMultiplication : public flit::TestBase<T> {
 public:
   DistributivityOfMultiplication(std::string id)
-    : QFPTest::TestBase<T>(std::move(id)) {}
+    : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput();
+  virtual flit::TestInput<T> getDefaultInput();
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() {
+  virtual flit::KernelFunction<T>* getKernel() {
     return DistOfMultKernel;
   }
 
   virtual
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     T a = ti.vals[0];
     T b = ti.vals[1];
     T c = ti.vals[2];
@@ -57,30 +55,30 @@ protected:
     auto distributed = (a * c) + (b * c);
     auto undistributed = (a + b) * c;
 
-    QFPHelpers::info_stream << std::setw(8);
-    QFPHelpers::info_stream << id << ": (a,b,c) = (" << a << ","
+    flit::info_stream << std::setw(8);
+    flit::info_stream << id << ": (a,b,c) = (" << a << ","
                 << b << "," << c << ")" << std::endl;
-    QFPHelpers::info_stream << id << ": dist    = "
+    flit::info_stream << id << ": dist    = "
                 << distributed << std::endl;
-    QFPHelpers::info_stream << id << ": undist  = "
+    flit::info_stream << id << ": undist  = "
                 << undistributed << std::endl;
 
     return {std::pair<long double, long double>(distributed, undistributed), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 // Define the inputs
 template<>
-inline QFPTest::TestInput<float>
+inline flit::TestInput<float>
 DistributivityOfMultiplication<float>::getDefaultInput() {
   auto convert = [](uint32_t x) {
-    return QFPHelpers::as_float(x);
+    return flit::as_float(x);
   };
 
-  QFPTest::TestInput<float> ti;
+  flit::TestInput<float> ti;
 
   // Put in canned values of previously found diverging inputs
   // These are entered as hex values to maintain the exact value instead of trying
@@ -135,13 +133,13 @@ DistributivityOfMultiplication<float>::getDefaultInput() {
 }
 
 template<>
-inline QFPTest::TestInput<double>
+inline flit::TestInput<double>
 DistributivityOfMultiplication<double>::getDefaultInput() {
   auto convert = [](uint64_t x) {
-    return QFPHelpers::as_float(x);
+    return flit::as_float(x);
   };
 
-  QFPTest::TestInput<double> ti;
+  flit::TestInput<double> ti;
 
   // Put in canned values of previously found diverging inputs
   // These are entered as hex values to maintain the exact value instead of trying
@@ -192,17 +190,17 @@ DistributivityOfMultiplication<double>::getDefaultInput() {
 }
 
 template<>
-inline QFPTest::TestInput<long double>
+inline flit::TestInput<long double>
 DistributivityOfMultiplication<long double>::getDefaultInput() {
   // Here we are assuming that long double represents 80 bits
   auto convert = [](uint64_t left_half, uint64_t right_half) {
     unsigned __int128 val = left_half;
     val = val << 64;
     val += right_half;
-    return QFPHelpers::as_float(val);
+    return flit::as_float(val);
   };
 
-  QFPTest::TestInput<long double> ti;
+  flit::TestInput<long double> ti;
 
   // Put in canned values of previously found diverging inputs
   // These are entered as hex values to maintain the exact value instead of trying

--- a/litmus-tests/tests/DoHariGSImproved.cpp
+++ b/litmus-tests/tests/DoHariGSImproved.cpp
@@ -4,21 +4,19 @@
 #include <cmath>
 #include <typeinfo>
 
-using namespace CUHelpers;
-
 template <typename T>
 GLOBAL
 void
-DoHGSITestKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
+DoHGSITestKernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
   auto idx = 0;
 #endif
   const T* vals = tiList[idx].vals;
-  VectorCU<T> a(vals, 3);
-  VectorCU<T> b(vals + 3, 3);
-  VectorCU<T> c(vals + 6, 3);
+  flit::VectorCU<T> a(vals, 3);
+  flit::VectorCU<T> b(vals + 3, 3);
+  flit::VectorCU<T> c(vals + 6, 3);
 
   auto r1 = a.getUnitVector();
   auto r2 = (b - r1 * (b ^ r1)).getUnitVector();
@@ -29,30 +27,30 @@ DoHGSITestKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultEleme
   T o13 = r1 ^ r3;
   T o23 = r2 ^ r3;
 
-  double score = abs(o12) + abs(o13) + abs(o23);
+  double score = std::abs(o12) + std::abs(o13) + std::abs(o23);
 
   results[idx].s1 = score;
   results[idx].s2 = 0;
 }
 
 template <typename T>
-class DoHariGSImproved: public QFPTest::TestBase<T> {
+class DoHariGSImproved: public flit::TestBase<T> {
 public:
-  DoHariGSImproved(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  DoHariGSImproved(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 9; }
-  virtual QFPTest::TestInput<T> getDefaultInput();
+  virtual flit::TestInput<T> getDefaultInput();
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return DoHGSITestKernel; }
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::KernelFunction<T>* getKernel() { return DoHGSITestKernel; }
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     long double score = 0.0;
 
     //matrix = {a, b, c};
-    QFPHelpers::Vector<T> a = {ti.vals[0], ti.vals[1], ti.vals[2]};
-    QFPHelpers::Vector<T> b = {ti.vals[3], ti.vals[4], ti.vals[5]};
-    QFPHelpers::Vector<T> c = {ti.vals[6], ti.vals[7], ti.vals[8]};
+    flit::Vector<T> a = {ti.vals[0], ti.vals[1], ti.vals[2]};
+    flit::Vector<T> b = {ti.vals[3], ti.vals[4], ti.vals[5]};
+    flit::Vector<T> c = {ti.vals[6], ti.vals[7], ti.vals[8]};
 
     auto r1 = a.getUnitVector();
     auto r2 = (b - r1 * (b ^ r1)).getUnitVector();
@@ -62,22 +60,22 @@ protected:
     T o13 = r1 ^ r3;
     T o23 = r2 ^ r3;
     if((score = std::abs(o12) + std::abs(o13) + std::abs(o23)) != 0){
-      QFPHelpers::info_stream << id << ": in: " << id << std::endl;
-      QFPHelpers::info_stream << id << ": applied gram-schmidt to:" << std::endl;
-      QFPHelpers::info_stream << id << ":   a:  " << a << std::endl;
-      QFPHelpers::info_stream << id << ":   b:  " << b << std::endl;
-      QFPHelpers::info_stream << id << ":   c:  " << c << std::endl;
-      QFPHelpers::info_stream << id << ": resulting vectors were:" << std::endl;
-      QFPHelpers::info_stream << id << ":   r1: " << r1 << std::endl;
-      QFPHelpers::info_stream << id << ":   r2: " << r2 << std::endl;
-      QFPHelpers::info_stream << id << ":   r3: " << r3 << std::endl;
-      QFPHelpers::info_stream << id << ": w dot prods: " << o12 << ", " << o13 << ", " << o23 << std::endl;
+      flit::info_stream << id << ": in: " << id << std::endl;
+      flit::info_stream << id << ": applied gram-schmidt to:" << std::endl;
+      flit::info_stream << id << ":   a:  " << a << std::endl;
+      flit::info_stream << id << ":   b:  " << b << std::endl;
+      flit::info_stream << id << ":   c:  " << c << std::endl;
+      flit::info_stream << id << ": resulting vectors were:" << std::endl;
+      flit::info_stream << id << ":   r1: " << r1 << std::endl;
+      flit::info_stream << id << ":   r2: " << r2 << std::endl;
+      flit::info_stream << id << ":   r3: " << r3 << std::endl;
+      flit::info_stream << id << ": w dot prods: " << o12 << ", " << o13 << ", " << o23 << std::endl;
     }
     return {std::pair<long double, long double>(score, 0.0l), 0l};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 namespace {
@@ -87,13 +85,13 @@ namespace {
 #ifndef __CUDA__
   template<> inline long double getSmallValue() { return pow(10, -10); }
 #endif
-}
+} // end of unnamed namespace
 
 template <typename T>
-QFPTest::TestInput<T> DoHariGSImproved<T>::getDefaultInput() {
+flit::TestInput<T> DoHariGSImproved<T>::getDefaultInput() {
   T e = getSmallValue<T>();
 
-  QFPTest::TestInput<T> ti;
+  flit::TestInput<T> ti;
 
   // Just one test
   ti.vals = {

--- a/litmus-tests/tests/DoMatrixMultSanity.cpp
+++ b/litmus-tests/tests/DoMatrixMultSanity.cpp
@@ -12,51 +12,51 @@
 template <typename T>
 GLOBAL
 void
-DoMatrixMultSanityKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
+DoMatrixMultSanityKernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
   auto idx = 0;
 #endif
   auto ti = tiList[idx];
-  auto b = CUHelpers::VectorCU<T>(ti.vals, ti.length);
-  auto c = CUHelpers::MatrixCU<T>::Identity(ti.length) * b;
+  auto b = flit::VectorCU<T>(ti.vals, ti.length);
+  auto c = flit::MatrixCU<T>::Identity(ti.length) * b;
   results[idx].s1 = c.L1Distance(b);
   results[idx].s2 = c.LInfDistance(b);
 }
 
 template <typename T>
-class DoMatrixMultSanity: public QFPTest::TestBase<T> {
+class DoMatrixMultSanity: public flit::TestBase<T> {
 public:
-  DoMatrixMultSanity(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  DoMatrixMultSanity(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 16; }
 
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.highestDim = getInputsPerRun();
     ti.min = -6;
     ti.max = 6;
     ti.vals = std::move(
-        QFPHelpers::Vector<T>::getRandomVector(getInputsPerRun()).getData());
+        flit::Vector<T>::getRandomVector(getInputsPerRun()).getData());
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return DoMatrixMultSanityKernel; }
+  virtual flit::KernelFunction<T>* getKernel() { return DoMatrixMultSanityKernel; }
   virtual
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     auto dim = ti.vals.size();
-    QFPHelpers::Vector<T> b(ti.vals);
-    auto c = QFPHelpers::Matrix<T>::Identity(dim) * b;
+    flit::Vector<T> b(ti.vals);
+    auto c = flit::Matrix<T>::Identity(dim) * b;
     bool eq = (c == b);
-    QFPHelpers::info_stream << id << ": Product is: " << c << std::endl;
-    QFPHelpers::info_stream << id << ": A * b == b? " << eq << std::endl;
+    flit::info_stream << id << ": Product is: " << c << std::endl;
+    flit::info_stream << id << ": A * b == b? " << eq << std::endl;
     return {std::pair<long double, long double>(c.L1Distance(b), c.LInfDistance(b)), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(DoMatrixMultSanity)

--- a/litmus-tests/tests/DoOrthoPerturbTest.cpp
+++ b/litmus-tests/tests/DoOrthoPerturbTest.cpp
@@ -5,14 +5,10 @@
 #include <typeinfo>
 #include <iomanip>
 
-using namespace CUHelpers;
-
 template <typename T>
 GLOBAL
 void
-DoOPTKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-  using namespace QFPHelpers;
-
+DoOPTKernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
@@ -27,8 +23,8 @@ DoOPTKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* r
   // we use a double literal above as a workaround for Intel 15-16 compiler
   // bug:
   // https://software.intel.com/en-us/forums/intel-c-compiler/topic/565143
-  VectorCU<T> a(ti.vals, ti.length);
-  VectorCU<T> b = a.genOrthoVector();
+  flit::VectorCU<T> a(ti.vals, ti.length);
+  flit::VectorCU<T> b = a.genOrthoVector();
 
   T backup;
 
@@ -36,8 +32,8 @@ DoOPTKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* r
     T &p = a[r];
     backup = p;
     for(decltype(iters) i = 0; i < iters; ++i){
-      auto tmp = as_int(p);
-      p = as_float(++tmp); //yeah, this isn't perfect
+      auto tmp = flit::as_int(p);
+      p = flit::as_float(++tmp); //yeah, this isn't perfect
       //p = std::nextafter(p, std::numeric_limits<T>::max());
       auto watchPoint = FLT_MIN;
       watchPoint = a ^ b;
@@ -46,10 +42,10 @@ DoOPTKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* r
       if(isOrth){
         orthoCount[r]++;
         // score should be perturbed amount
-        if(i != 0) score += abs(p - backup);
+        if(i != 0) score += std::abs(p - backup);
       }else{
         // if falsely not detecting ortho, should be the dot prod
-        if(i == 0) score += abs(watchPoint); //a ^ b);  
+        if(i == 0) score += std::abs(watchPoint); //a ^ b);  
       }
     }
     p = backup;
@@ -59,13 +55,13 @@ DoOPTKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* r
 }
 
 template <typename T>
-class DoOrthoPerturbTest : public QFPTest::TestBase<T> {
+class DoOrthoPerturbTest : public flit::TestBase<T> {
 public:
-  DoOrthoPerturbTest(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  DoOrthoPerturbTest(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 16; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.iters = 200;
     ti.ulp_inc = 1;
 
@@ -78,10 +74,10 @@ public:
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return DoOPTKernel; }
+  virtual flit::KernelFunction<T>* getKernel() { return DoOPTKernel; }
   virtual
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
-    using QFPHelpers::operator<<;
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
+    using flit::operator<<;
 
     auto iters = ti.iters;
     auto dim = getInputsPerRun();
@@ -91,8 +87,8 @@ protected:
     // we use a double literal above as a workaround for Intel 15-16 compiler
     // bug:
     // https://software.intel.com/en-us/forums/intel-c-compiler/topic/565143
-    QFPHelpers::Vector<T> a(ti.vals);
-    QFPHelpers::Vector<T> b = a.genOrthoVector();
+    flit::Vector<T> a(ti.vals);
+    flit::Vector<T> b = a.genOrthoVector();
 
     T backup;
 
@@ -120,27 +116,27 @@ protected:
           // if falsely not detecting ortho, should be the dot prod
           if(i == 0) score += std::abs(watchPoint); //a ^ b);
         }
-        QFPHelpers::info_stream
+        flit::info_stream
           << "i:" << i
-          << ":a[" << r << "] = " << a[r] << ", " << QFPHelpers::as_int(a[r])
-          << " multiplier: " << b[r] << ", " << QFPHelpers::as_int(b[r])
+          << ":a[" << r << "] = " << a[r] << ", " << flit::as_int(a[r])
+          << " multiplier: " << b[r] << ", " << flit::as_int(b[r])
           << " perp: " << isOrth
-          << " dot prod: " << QFPHelpers::as_int(a ^ b)
+          << " dot prod: " << flit::as_int(a ^ b)
           << std::endl;
       }
-      QFPHelpers::info_stream << "next dimension . . . " << std::endl;
+      flit::info_stream << "next dimension . . . " << std::endl;
       p = backup;
     }
-    QFPHelpers::info_stream << "Final report, one iteration set per dimensiion:" << std::endl;
-    QFPHelpers::info_stream << '\t' << "ulp increment per loop: " << ulp_inc << std::endl;
-    QFPHelpers::info_stream << '\t' << "iterations per dimension: " << iters << std::endl;
-    QFPHelpers::info_stream << '\t' << "dimensions: " << dim << std::endl;
-    QFPHelpers::info_stream << '\t' << "precision (type): " << typeid(T).name() << std::endl;
+    flit::info_stream << "Final report, one iteration set per dimensiion:" << std::endl;
+    flit::info_stream << '\t' << "ulp increment per loop: " << ulp_inc << std::endl;
+    flit::info_stream << '\t' << "iterations per dimension: " << iters << std::endl;
+    flit::info_stream << '\t' << "dimensions: " << dim << std::endl;
+    flit::info_stream << '\t' << "precision (type): " << typeid(T).name() << std::endl;
     int cdim = 0;
     for(auto d: orthoCount){
       int exp = 0;
       std::frexp(a[cdim] * b[cdim], &exp);
-      QFPHelpers::info_stream
+      flit::info_stream
         << "For mod dim " << cdim << ", there were " << d
         << " ortho vectors, product magnitude (biased fp exp): " << exp
         << std::endl;
@@ -150,7 +146,7 @@ protected:
   }
 
 private:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(DoOrthoPerturbTest)

--- a/litmus-tests/tests/DoSimpleRotate90.cpp
+++ b/litmus-tests/tests/DoSimpleRotate90.cpp
@@ -5,21 +5,19 @@
 #include "QFPHelpers.hpp"
 #include "CUHelpers.hpp"
 
-using namespace CUHelpers;
-
 template <typename T>
 GLOBAL
 void
-DoSR90Kernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
+DoSR90Kernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
   auto idx = 0;
 #endif
   auto ti = tiList[idx];
-  VectorCU<T> A(ti.vals, ti.length);
+  flit::VectorCU<T> A(ti.vals, ti.length);
 
-  VectorCU<T> expected(A.size());
+  flit::VectorCU<T> expected(A.size());
   expected[0]=-A[1]; expected[1]=A[0]; expected[2]=A[2];
 
   auto done = A.rotateAboutZ_3d(M_PI/2);
@@ -29,34 +27,34 @@ DoSR90Kernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* 
 }
 
 template <typename T>
-class DoSimpleRotate90: public QFPTest::TestBase<T> {
+class DoSimpleRotate90: public flit::TestBase<T> {
 public:
-  DoSimpleRotate90(std::string id):QFPTest::TestBase<T>(std::move(id)) {}
+  DoSimpleRotate90(std::string id):flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = { 1, 1, 1 };
     return ti;
   }
-  virtual QFPTest::KernelFunction<T>* getKernel() { return DoSR90Kernel; }
+  virtual flit::KernelFunction<T>* getKernel() { return DoSR90Kernel; }
 
 protected:
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
-    QFPHelpers::Vector<T> A(ti.vals);
-    QFPHelpers::Vector<T> expected = {-A[1], A[0], A[2]};
-    QFPHelpers::info_stream << "Rotating A: " << A << ", 1/2 PI radians" << std::endl;
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
+    flit::Vector<T> A(ti.vals);
+    flit::Vector<T> expected = {-A[1], A[0], A[2]};
+    flit::info_stream << "Rotating A: " << A << ", 1/2 PI radians" << std::endl;
     A = A.rotateAboutZ_3d(M_PI/2);
-    QFPHelpers::info_stream << "Resulting vector: " << A << std::endl;
-    QFPHelpers::info_stream << "in " << id << std::endl;
-    A.dumpDistanceMetrics(expected, QFPHelpers::info_stream);
+    flit::info_stream << "Resulting vector: " << A << std::endl;
+    flit::info_stream << "in " << id << std::endl;
+    A.dumpDistanceMetrics(expected, flit::info_stream);
     return {std::pair<long double, long double>(A.L1Distance(expected),
 						A.LInfDistance(expected)),
 	0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(DoSimpleRotate90)

--- a/litmus-tests/tests/DoSkewSymCPRotationTest.cpp
+++ b/litmus-tests/tests/DoSkewSymCPRotationTest.cpp
@@ -5,25 +5,23 @@
 #include "QFPHelpers.hpp"
 #include "CUHelpers.hpp"
 
-using namespace CUHelpers;
-
 template <typename T>
 GLOBAL
 void
-DoSkewSCPRKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
+DoSkewSCPRKernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
   auto idx = 0;
 #endif
   const T* vals = tiList[idx].vals;
-  auto A = VectorCU<T>(vals, 3).getUnitVector();
-  auto B = VectorCU<T>(vals + 3, 3).getUnitVector();
+  auto A = flit::VectorCU<T>(vals, 3).getUnitVector();
+  auto B = flit::VectorCU<T>(vals + 3, 3).getUnitVector();
   auto cross = A.cross(B);
   auto sine = cross.L2Norm();
   auto cos = A ^ B;
-  auto sscpm = MatrixCU<T>::SkewSymCrossProdM(cross);
-  auto rMatrix = MatrixCU<T>::Identity(3) +
+  auto sscpm = flit::MatrixCU<T>::SkewSymCrossProdM(cross);
+  auto rMatrix = flit::MatrixCU<T>::Identity(3) +
     sscpm + (sscpm * sscpm) * ((1 - cos)/(sine * sine));
   auto result = rMatrix * A;
   results[idx].s1 = result.L1Distance(B);
@@ -31,70 +29,70 @@ DoSkewSCPRKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultEleme
 }
 
 template <typename T>
-class DoSkewSymCPRotationTest: public QFPTest::TestBase<T> {
+class DoSkewSymCPRotationTest: public flit::TestBase<T> {
 public:
   DoSkewSymCPRotationTest(std::string id)
-    : QFPTest::TestBase<T>(std::move(id)) {}
+    : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 6; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.min = -6;
     ti.max = 6;
     auto n = getInputsPerRun();
     ti.highestDim = n;
-    ti.vals = QFPHelpers::Vector<T>::getRandomVector(n).getData();
+    ti.vals = flit::Vector<T>::getRandomVector(n).getData();
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return DoSkewSCPRKernel;}
+  virtual flit::KernelFunction<T>* getKernel() { return DoSkewSCPRKernel;}
 
   virtual
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
-    QFPHelpers::info_stream << "entered " << id << std::endl;
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
+    flit::info_stream << "entered " << id << std::endl;
     long double L1Score = 0.0;
     long double LIScore = 0.0;
-    QFPHelpers::Vector<T> A = { ti.vals[0], ti.vals[1], ti.vals[2] };
-    QFPHelpers::Vector<T> B = { ti.vals[3], ti.vals[4], ti.vals[5] };
+    flit::Vector<T> A = { ti.vals[0], ti.vals[1], ti.vals[2] };
+    flit::Vector<T> B = { ti.vals[3], ti.vals[4], ti.vals[5] };
     A = A.getUnitVector();
     B = B.getUnitVector();
-    QFPHelpers::info_stream << "A (unit) is: " << std::endl << A << std::endl;
-    QFPHelpers::info_stream << "B (unit): " << std::endl  << B << std::endl;
+    flit::info_stream << "A (unit) is: " << std::endl << A << std::endl;
+    flit::info_stream << "B (unit): " << std::endl  << B << std::endl;
     auto cross = A.cross(B); //cross product
-    QFPHelpers::info_stream << "cross: " << std::endl << cross << std::endl;
+    flit::info_stream << "cross: " << std::endl << cross << std::endl;
     auto sine = cross.L2Norm();
-    QFPHelpers::info_stream << "sine: " << std::endl << sine << std::endl;
+    flit::info_stream << "sine: " << std::endl << sine << std::endl;
     //    crit = A ^ B; //dot product
     auto cos = A ^ B;
-    //    QFPHelpers::info_stream << "cosine: " << std::endl << crit << std::endl;
-    QFPHelpers::info_stream << "cosine: " << std::endl << cos << std::endl;
-    auto sscpm = QFPHelpers::Matrix<T>::SkewSymCrossProdM(cross);
-    QFPHelpers::info_stream << "sscpm: " << std::endl << sscpm << std::endl;
-    auto rMatrix = QFPHelpers::Matrix<T>::Identity(3) +
+    //    flit::info_stream << "cosine: " << std::endl << crit << std::endl;
+    flit::info_stream << "cosine: " << std::endl << cos << std::endl;
+    auto sscpm = flit::Matrix<T>::SkewSymCrossProdM(cross);
+    flit::info_stream << "sscpm: " << std::endl << sscpm << std::endl;
+    auto rMatrix = flit::Matrix<T>::Identity(3) +
       sscpm + (sscpm * sscpm) * ((1 - cos)/(sine * sine));
-    // auto rMatrix = QFPHelpers::Matrix<T>::Identity(3) +
+    // auto rMatrix = flit::Matrix<T>::Identity(3) +
     //   sscpm + (sscpm * sscpm) * ((1 - crit)/(sine * sine));
     auto result = rMatrix * A;
-    QFPHelpers::info_stream << "rotator: " << std::endl << rMatrix << std::endl;
+    flit::info_stream << "rotator: " << std::endl << rMatrix << std::endl;
     if(!(result == B)){
       L1Score = result.L1Distance(B);
       LIScore = result.LInfDistance(B);
-      QFPHelpers::info_stream << "Skew symmetric cross product rotation failed with ";
-      QFPHelpers::info_stream << "L1Distance " << L1Score << std::endl;
-      QFPHelpers::info_stream << "starting vectors: " << std::endl;
-      QFPHelpers::info_stream << A << std::endl;
-      QFPHelpers::info_stream << "...and..." << std::endl;
-      QFPHelpers::info_stream << B << std::endl;
-      QFPHelpers::info_stream << "ended up with: " << std::endl;
-      QFPHelpers::info_stream << "L1Distance: " << L1Score << std::endl;
-      QFPHelpers::info_stream << "LIDistance: " << LIScore << std::endl;
+      flit::info_stream << "Skew symmetric cross product rotation failed with ";
+      flit::info_stream << "L1Distance " << L1Score << std::endl;
+      flit::info_stream << "starting vectors: " << std::endl;
+      flit::info_stream << A << std::endl;
+      flit::info_stream << "...and..." << std::endl;
+      flit::info_stream << B << std::endl;
+      flit::info_stream << "ended up with: " << std::endl;
+      flit::info_stream << "L1Distance: " << L1Score << std::endl;
+      flit::info_stream << "LIDistance: " << LIScore << std::endl;
     }
     return {std::pair<long double, long double>(L1Score, LIScore), 0};
   }
 
 private:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(DoSkewSymCPRotationTest)

--- a/litmus-tests/tests/FMACancel.cpp
+++ b/litmus-tests/tests/FMACancel.cpp
@@ -8,20 +8,20 @@
 #include <cstdlib>
 
 template <typename T>
-class FMACancel : public QFPTest::TestBase<T> {
+class FMACancel : public flit::TestBase<T> {
 public:
-  FMACancel(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  FMACancel(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 2; }
 
-  QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = { .1, 1.1e5 };
     return ti;
   }
 
 protected:
-  virtual QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     const T a = ti.vals[0];
     const T b = ti.vals[1];
     const T c = a;
@@ -30,13 +30,13 @@ protected:
     const T score = a*b + c*d;
     const T rtemp = c*d;
     const T score2 = a*b + rtemp;
-    QFPHelpers::info_stream << id << ": score  = " << score  << std::endl;
-    QFPHelpers::info_stream << id << ": score2 = " << score2 << std::endl;
+    flit::info_stream << id << ": score  = " << score  << std::endl;
+    flit::info_stream << id << ": score2 = " << score2 << std::endl;
     return {std::pair<long double, long double>(score, score2), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 

--- a/litmus-tests/tests/InliningProblem.cpp
+++ b/litmus-tests/tests/InliningProblem.cpp
@@ -8,14 +8,14 @@
 #include <cstdlib>
 
 template <typename T>
-class InliningProblem : public QFPTest::TestBase<T> {
+class InliningProblem : public flit::TestBase<T> {
 public:
-  InliningProblem(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  InliningProblem(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 1; }
 
-  QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = { .1, 1.1e3, -.1, -1.1e3, 1/3 };
     return ti;
   }
@@ -26,20 +26,20 @@ protected:
     const T x_again = -nx;
     return x_again;
   }
-  virtual QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     T a = ti.vals[0];
     T also_a = identity(a);
 
     const T score = std::sqrt(a) * std::sqrt(also_a);
     const T score2 = std::pow(std::sqrt(a), 2);
 
-    QFPHelpers::info_stream << id << ": score  = " << score  << std::endl;
-    QFPHelpers::info_stream << id << ": score2 = " << score2 << std::endl;
+    flit::info_stream << id << ": score  = " << score  << std::endl;
+    flit::info_stream << id << ": score2 = " << score2 << std::endl;
     return {std::pair<long double, long double>(score, score2), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 

--- a/litmus-tests/tests/KahanSum.cpp
+++ b/litmus-tests/tests/KahanSum.cpp
@@ -13,15 +13,15 @@
 #define EXP 2.71828182845904523536028747L
 
 template <typename T>
-class KahanSum : public QFPTest::TestBase<T> {
+class KahanSum : public flit::TestBase<T> {
 public:
-  KahanSum(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  KahanSum(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 10000; }
-  virtual QFPTest::TestInput<T> getDefaultInput();
+  virtual flit::TestInput<T> getDefaultInput();
 
 protected:
-  virtual QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     Kahan<T> kahan;
     Shewchuk<T> chuk;
     T naive = 0.0;
@@ -30,17 +30,17 @@ protected:
       kahan.add(val);
       naive += val;
     }
-    QFPHelpers::info_stream << id << ": pi           = " << static_cast<T>(PI) << std::endl;
-    QFPHelpers::info_stream << id << ": exp(1)       = " << static_cast<T>(EXP) << std::endl;
-    QFPHelpers::info_stream << id << ": naive sum    = " << naive << std::endl;
-    QFPHelpers::info_stream << id << ": kahan sum    = " << kahan.sum() << std::endl;
-    QFPHelpers::info_stream << id << ": shewchuk sum = " << kahan.sum() << std::endl;
-    QFPHelpers::info_stream << id << ": Epsilon      = " << std::numeric_limits<T>::epsilon() << std::endl;
+    flit::info_stream << id << ": pi           = " << static_cast<T>(PI) << std::endl;
+    flit::info_stream << id << ": exp(1)       = " << static_cast<T>(EXP) << std::endl;
+    flit::info_stream << id << ": naive sum    = " << naive << std::endl;
+    flit::info_stream << id << ": kahan sum    = " << kahan.sum() << std::endl;
+    flit::info_stream << id << ": shewchuk sum = " << kahan.sum() << std::endl;
+    flit::info_stream << id << ": Epsilon      = " << std::numeric_limits<T>::epsilon() << std::endl;
     return {std::pair<long double, long double>(kahan.sum(), naive), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 namespace {
@@ -51,11 +51,11 @@ namespace {
 #ifndef __CUDA__
   template<> std::vector<long double> getToRepeat() { return { 1.0e14, PI, EXP, -1.0e14 }; }
 #endif
-}
+} // end of unnamed namespace
 
 template <typename T>
-QFPTest::TestInput<T> KahanSum<T>::getDefaultInput() {
-  QFPTest::TestInput<T> ti;
+flit::TestInput<T> KahanSum<T>::getDefaultInput() {
+  flit::TestInput<T> ti;
   auto dim = getInputsPerRun();
   ti.highestDim = dim;
   ti.vals = std::vector<T>(dim);

--- a/litmus-tests/tests/Paranoia.cpp
+++ b/litmus-tests/tests/Paranoia.cpp
@@ -193,7 +193,7 @@ extern "C" typedef void (*SigType)(int);
 typedef int Guard, Rounding, Class;
 typedef char Message;
 
-using QFPHelpers::info_stream;
+using flit::info_stream;
 using std::endl;
 
 /// Custom exceptions to throw for the Paranoia test
@@ -206,15 +206,15 @@ class FlawError     : public ParanoiaError {};
 class OverflowError : public ParanoiaError {};
 
 template <typename F>
-class Paranoia : public QFPTest::TestBase<F> {
+class Paranoia : public flit::TestBase<F> {
 public:
-  Paranoia(std::string id) : QFPTest::TestBase<F>(std::move(id)) {}
+  Paranoia(std::string id) : flit::TestBase<F>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 0; }
-  virtual QFPTest::TestInput<F> getDefaultInput() { return {}; }
+  virtual flit::TestInput<F> getDefaultInput() { return {}; }
 
 protected:
-  virtual QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<F>& ti);
+  virtual flit::ResultType::mapped_type run_impl(const flit::TestInput<F>& ti);
 
   void   setTimeout(long millis);  // starts the timer for checkTimeout()
   void   checkTimeout();          // throws TimeoutError if timer from setTimeout has expired
@@ -239,7 +239,7 @@ protected:
   F      pow(F x_, F y_);
 
 protected:
-  using QFPTest::TestBase<F>::id;
+  using flit::TestBase<F>::id;
 
   std::chrono::steady_clock::time_point startTime;
   std::chrono::steady_clock::time_point timeoutTime;
@@ -304,7 +304,7 @@ namespace {
   int fpecount = 0;
   jmp_buf ovfl_buf;
   SigType sigsave = nullptr;
-}
+} // end of unnamed namespace
 
 /* floating point exception receiver */
 void sigfpe(int i)
@@ -322,7 +322,7 @@ void sigfpe(int i)
 }
 
 template <typename F>
-QFPTest::ResultType::mapped_type Paranoia<F>::run_impl(const QFPTest::TestInput<F>& ti)
+flit::ResultType::mapped_type Paranoia<F>::run_impl(const flit::TestInput<F>& ti)
 {
   Q_UNUSED(ti);
   int timeoutMillis = 1000;
@@ -395,7 +395,7 @@ QFPTest::ResultType::mapped_type Paranoia<F>::run_impl(const QFPTest::TestInput<
          && (minusOne + one == zero ) && (one + minusOne == zero)
          && (minusOne + std::abs(one) == zero)
          && (minusOne + minusOne * minusOne == zero),
-         "-1+1 != 0, (-1)+abs(1) != 0, or -1+(-1)*(-1) != 0");
+         "-1+1 != 0, (-1)+std::abs(1) != 0, or -1+(-1)*(-1) != 0");
     tstCond (Failure, half + minusOne + half == zero,
         "1/2 + (-1) + 1/2 != 0");
     /*=============================================*/

--- a/litmus-tests/tests/ReciprocalMath.cpp
+++ b/litmus-tests/tests/ReciprocalMath.cpp
@@ -8,20 +8,20 @@
 #include <cstdlib>
 
 template <typename T>
-class ReciprocalMath : public QFPTest::TestBase<T> {
+class ReciprocalMath : public flit::TestBase<T> {
 public:
-  ReciprocalMath(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  ReciprocalMath(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 5; }
 
-  QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = { .1, 1.1e3, -.1, -1.1e3, 1/3 };
     return ti;
   }
 
 protected:
-  virtual QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     T a = ti.vals[0];
     T b = ti.vals[1];
     T c = ti.vals[2];
@@ -36,13 +36,13 @@ protected:
     const T score = a + c;
     const T score2 = b + d;
 
-    QFPHelpers::info_stream << id << ": score  = " << score  << std::endl;
-    QFPHelpers::info_stream << id << ": score2 = " << score2 << std::endl;
+    flit::info_stream << id << ": score  = " << score  << std::endl;
+    flit::info_stream << id << ": score2 = " << score2 << std::endl;
     return {std::pair<long double, long double>(score, score2), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 

--- a/litmus-tests/tests/RotateAndUnrotate.cpp
+++ b/litmus-tests/tests/RotateAndUnrotate.cpp
@@ -9,8 +9,7 @@
 template <typename T>
 GLOBAL
 void
-RaUKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-  using namespace CUHelpers;
+RaUKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
@@ -18,7 +17,7 @@ RaUKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* resul
 #endif
   auto theta = M_PI;
   auto ti = tiList[idx];
-  auto A = VectorCU<T>(ti.vals, ti.length);
+  auto A = flit::VectorCU<T>(ti.vals, ti.length);
   auto orig = A;
   A = A.rotateAboutZ_3d(theta);
   A = A.rotateAboutZ_3d(-theta);
@@ -27,45 +26,45 @@ RaUKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* resul
 }
 
 template <typename T>
-class RotateAndUnrotate: public QFPTest::TestBase<T> {
+class RotateAndUnrotate: public flit::TestBase<T> {
 public:
-  RotateAndUnrotate(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  RotateAndUnrotate(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.min = -6;
     ti.max = 6;
-    ti.vals = QFPHelpers::Vector<T>::getRandomVector(3).getData();
+    ti.vals = flit::Vector<T>::getRandomVector(3).getData();
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return RaUKern; }
+  virtual flit::KernelFunction<T>* getKernel() { return RaUKern; }
   virtual
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     auto theta = M_PI;
-    auto A = QFPHelpers::Vector<T>(ti.vals);
+    auto A = flit::Vector<T>(ti.vals);
     auto orig = A;
-    QFPHelpers::info_stream << "Rotate and Unrotate by " << theta << " radians, A is: " << A << std::endl;
+    flit::info_stream << "Rotate and Unrotate by " << theta << " radians, A is: " << A << std::endl;
     A.rotateAboutZ_3d(theta);
-    QFPHelpers::info_stream << "Rotated is: " << A << std::endl;
+    flit::info_stream << "Rotated is: " << A << std::endl;
     A.rotateAboutZ_3d(-theta);
-    QFPHelpers::info_stream << "Unrotated is: " << A << std::endl;
+    flit::info_stream << "Unrotated is: " << A << std::endl;
     bool equal = A == orig;
-    QFPHelpers::info_stream << "Are they equal? " << equal << std::endl;
+    flit::info_stream << "Are they equal? " << equal << std::endl;
     auto dist = A.L1Distance(orig);
     if(!equal){
-      QFPHelpers::info_stream << "error in L1 distance is: " << dist << std::endl;
-      QFPHelpers::info_stream << "difference between: " << (A - orig) << std::endl;
+      flit::info_stream << "error in L1 distance is: " << dist << std::endl;
+      flit::info_stream << "difference between: " << (A - orig) << std::endl;
     }
-    QFPHelpers::info_stream << "in " << id << std::endl;
-    A.dumpDistanceMetrics(orig, QFPHelpers::info_stream);
+    flit::info_stream << "in " << id << std::endl;
+    A.dumpDistanceMetrics(orig, flit::info_stream);
     return {std::pair<long double, long double>(dist, A.LInfDistance(orig)), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(RotateAndUnrotate)

--- a/litmus-tests/tests/RotateFullCircle.cpp
+++ b/litmus-tests/tests/RotateFullCircle.cpp
@@ -5,12 +5,10 @@
 #include "QFPHelpers.hpp"
 #include "CUHelpers.hpp"
 
-using namespace CUHelpers;
-
 template <typename T>
 GLOBAL
 void
-RFCKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
+RFCKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
@@ -18,7 +16,7 @@ RFCKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* resul
 #endif
   auto ti = tiList[idx];
   auto n = ti.iters;
-  auto A = VectorCU<T>(ti.vals, ti.length);
+  auto A = flit::VectorCU<T>(ti.vals, ti.length);
   auto orig = A;
   T theta = 2 * M_PI / n;
   for(decltype(n) r = 0; r < n; ++r){
@@ -29,48 +27,48 @@ RFCKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* resul
 }
 
 template <typename T>
-class RotateFullCircle: public QFPTest::TestBase<T> {
+class RotateFullCircle: public flit::TestBase<T> {
 public:
-  RotateFullCircle(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  RotateFullCircle(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.min = -6;
     ti.max = 6;
     ti.iters = 200;
     auto n = getInputsPerRun();
     ti.highestDim = n;
-    ti.vals = QFPHelpers::Vector<T>::getRandomVector(n).getData();
+    ti.vals = flit::Vector<T>::getRandomVector(n).getData();
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() {return RFCKern; }
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::KernelFunction<T>* getKernel() {return RFCKern; }
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     auto n = ti.iters;
-    QFPHelpers::Vector<T> A = QFPHelpers::Vector<T>(ti.vals);
+    flit::Vector<T> A = flit::Vector<T>(ti.vals);
     auto orig = A;
     T theta = 2 * M_PI / n;
-    QFPHelpers::info_stream << "Rotate full circle in " << n << " increments, A is: " << A << std::endl;
+    flit::info_stream << "Rotate full circle in " << n << " increments, A is: " << A << std::endl;
     for(decltype(n) r = 0; r < n; ++r){
       A.rotateAboutZ_3d(theta);
-      QFPHelpers::info_stream << r << " rotations, vect = " << A << std::endl;
+      flit::info_stream << r << " rotations, vect = " << A << std::endl;
     }
-    QFPHelpers::info_stream << "Rotated is: " << A << std::endl;
+    flit::info_stream << "Rotated is: " << A << std::endl;
     bool equal = A == orig;
-    QFPHelpers::info_stream << "Does rotated vect == starting vect? " << equal << std::endl;
+    flit::info_stream << "Does rotated vect == starting vect? " << equal << std::endl;
     if(!equal){
-      QFPHelpers::info_stream << "The (vector) difference is: " << (A - orig) << std::endl;
+      flit::info_stream << "The (vector) difference is: " << (A - orig) << std::endl;
     }
-    QFPHelpers::info_stream << "in " << id << std::endl;
-    A.dumpDistanceMetrics(orig, QFPHelpers::info_stream);
+    flit::info_stream << "in " << id << std::endl;
+    A.dumpDistanceMetrics(orig, flit::info_stream);
     return {std::pair<long double, long double>(A.L1Distance(orig),
 						A.LInfDistance(orig)), 0};
   }
 
 private:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(RotateFullCircle)

--- a/litmus-tests/tests/ShewchukSum.cpp
+++ b/litmus-tests/tests/ShewchukSum.cpp
@@ -9,42 +9,42 @@
 #include <vector>
 
 template <typename T>
-class ShewchukSum : public QFPTest::TestBase<T> {
+class ShewchukSum : public flit::TestBase<T> {
 public:
-  ShewchukSum(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  ShewchukSum(std::string id) : flit::TestBase<T>(std::move(id)) {}
   
   virtual size_t getInputsPerRun() { return 1000; }
-  virtual QFPTest::TestInput<T> getDefaultInput();
+  virtual flit::TestInput<T> getDefaultInput();
 
 protected:
-  virtual QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     Shewchuk<T> chuk;
     T naive = 0.0;
     for (auto val : ti.vals) {
       chuk.add(val);
       naive += val;
-      //QFPHelpers::info_stream
+      //flit::info_stream
       //  << std::setw(7)
       //  << std::setprecision(7)
       //  << id << ": + " << val
       //  << " = " << chuk.sum() << " or " << naive
       //  << std::endl;
-			QFPHelpers::info_stream
+			flit::info_stream
 				<< id << ":   partials now: (" << chuk.partials().size() << ") ";
       for (auto p : chuk.partials()) {
-        QFPHelpers::info_stream << " " << p;
+        flit::info_stream << " " << p;
       }
-      QFPHelpers::info_stream << std::endl;
+      flit::info_stream << std::endl;
     }
     T sum = chuk.sum();
-    QFPHelpers::info_stream << id << ": naive sum    = " << naive << std::endl;
-    QFPHelpers::info_stream << id << ": shewchuk sum = " << sum << std::endl;
-    QFPHelpers::info_stream << id << ": shewchuk partials = " << chuk.partials().size() << std::endl;
+    flit::info_stream << id << ": naive sum    = " << naive << std::endl;
+    flit::info_stream << id << ": shewchuk sum = " << sum << std::endl;
+    flit::info_stream << id << ": shewchuk partials = " << chuk.partials().size() << std::endl;
     return {std::pair<long double, long double>(sum, chuk.sum2()), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 namespace {
@@ -54,11 +54,11 @@ namespace {
 #ifndef __CUDA__
   template<> std::vector<long double> getToRepeat() { return { 1.0, 1.0e200, 1.0, -1.0e200 }; }
 #endif
-}
+} // end of unnamed namespace
 
 template <typename T>
-QFPTest::TestInput<T> ShewchukSum<T>::getDefaultInput() {
-  QFPTest::TestInput<T> ti;
+flit::TestInput<T> ShewchukSum<T>::getDefaultInput() {
+  flit::TestInput<T> ti;
   auto dim = getInputsPerRun();
   ti.highestDim = dim;
   ti.vals = std::vector<T>(dim);

--- a/litmus-tests/tests/SinInt.cpp
+++ b/litmus-tests/tests/SinInt.cpp
@@ -9,32 +9,32 @@
 #include <cstdlib>
 
 template <typename T>
-class SinInt : public QFPTest::TestBase<T> {
+class SinInt : public flit::TestBase<T> {
 public:
-  SinInt(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  SinInt(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 1; }
 
-  QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     const T pi = 3.141592653589793238462643383279502884197169399375105820974944592307816406286208998L;
     ti.vals = { pi };
     return ti;
   }
 
 protected:
-  virtual QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     const int zero = (rand() % 10) / 99;
     const T val = ti.vals[0];
     const T score = std::sin(val + zero) / std::sin(val);
     const T score2 = score - 1.0;
-    QFPHelpers::info_stream << id << ": score  = " << score  << std::endl;
-    QFPHelpers::info_stream << id << ": score2 = " << score2 << std::endl;
+    flit::info_stream << id << ": score  = " << score  << std::endl;
+    flit::info_stream << id << ": score2 = " << score2 << std::endl;
     return {std::pair<long double, long double>(score, score2), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 

--- a/litmus-tests/tests/TrianglePHeron.cpp
+++ b/litmus-tests/tests/TrianglePHeron.cpp
@@ -12,7 +12,7 @@ T getCArea(const T a,
           const T b,
           const T c){
     T s = (a + b + c ) / 2;
-    return CUHelpers::csqrt((T)s * (s-a) * (s-b) * (s-c));
+    return flit::csqrt((T)s * (s-a) * (s-b) * (s-c));
 }
 
 template <typename T>
@@ -26,8 +26,7 @@ T getArea(const T a,
 template <typename T>
 GLOBAL
 void
-TrianglePHKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results) {
-  using namespace CUHelpers;
+TrianglePHKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results) {
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
@@ -37,32 +36,32 @@ TrianglePHKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement
   T maxval = tiList[idx].vals[0];
   T a = maxval;
   T b = maxval;
-  T c = maxval * csqrt((T)2.0);
+  T c = maxval * flit::csqrt((T)2.0);
   const T delta = maxval / (T)ti.iters;
   const T checkVal = (T)0.5 * b * a;
 
   double score = 0.0;
 
   for(T pos = 0; pos <= a; pos += delta){
-    b = csqrt(cpow(pos, (T)2.0) +
-	      cpow(maxval, (T)2.0));
-    c = csqrt(cpow(a - pos, (T)2.0) +
-	      cpow(maxval, (T)2.0));
+    b = flit::csqrt(flit::cpow(pos, (T)2.0) +
+	      flit::cpow(maxval, (T)2.0));
+    c = flit::csqrt(flit::cpow(a - pos, (T)2.0) +
+	      flit::cpow(maxval, (T)2.0));
     auto crit = getCArea(a,b,c);
-    score += abs(crit - checkVal);
+    score += std::abs(crit - checkVal);
   }
   results[idx].s1 = score;
   results[idx].s2 = 0.0;
 }
 
 template <typename T>
-class TrianglePHeron: public QFPTest::TestBase<T> {
+class TrianglePHeron: public flit::TestBase<T> {
 public:
-  TrianglePHeron(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  TrianglePHeron(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.iters = 200;
     ti.vals = { 6.0 };
     return ti;
@@ -70,9 +69,9 @@ public:
 
 protected:
   virtual
-  QFPTest::KernelFunction<T>* getKernel() {return TrianglePHKern; }
+  flit::KernelFunction<T>* getKernel() {return TrianglePHKern; }
   virtual
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     T maxval = ti.vals[0];
     // start as a right triangle
     T a = maxval;
@@ -99,7 +98,7 @@ protected:
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(TrianglePHeron)

--- a/litmus-tests/tests/TrianglePSylv.cpp
+++ b/litmus-tests/tests/TrianglePSylv.cpp
@@ -10,7 +10,7 @@ DEVICE
 T getCArea(const T a,
           const T b,
           const T c){
-  return (CUHelpers::cpow((T)2.0, (T)-2)*CUHelpers::csqrt((T)(a+(b+c))*(a+(b-c))*(c+(a-b))*(c-(a-b))));
+  return (flit::cpow((T)2.0, (T)-2)*flit::csqrt((T)(a+(b+c))*(a+(b-c))*(c+(a-b))*(c-(a-b))));
 }
 
 template <typename T>
@@ -23,8 +23,7 @@ T getArea(const T a,
 template <typename T>
 GLOBAL
 void
-TrianglePSKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-  using namespace CUHelpers;
+TrianglePSKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 #ifdef __CUDA__
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 #else
@@ -34,32 +33,32 @@ TrianglePSKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement
   T maxval = tiList[idx].vals[0];
   T a = maxval;
   T b = maxval;
-  T c = maxval * csqrt((T)2.0);
+  T c = maxval * flit::csqrt((T)2.0);
   const T delta = maxval / (T)ti.iters;
   const T checkVal = (T)0.5 * b * a;
 
   double score = 0.0;
 
   for(T pos = 0; pos <= a; pos += delta){
-    b = csqrt(cpow(pos, (T)2.0) +
-	      cpow(maxval, (T)2.0));
-    c = csqrt(cpow(a - pos, (T)2.0) +
-	      cpow(maxval, (T)2.0));
+    b = flit::csqrt(flit::cpow(pos, (T)2.0) +
+	      flit::cpow(maxval, (T)2.0));
+    c = flit::csqrt(flit::cpow(a - pos, (T)2.0) +
+	      flit::cpow(maxval, (T)2.0));
     auto crit = getCArea(a,b,c);
-    score += abs(crit - checkVal);
+    score += std::abs(crit - checkVal);
   }
   results[idx].s1 = score;
   results[idx].s2 = 0.0;
 }
 
 template <typename T>
-class TrianglePSylv: public QFPTest::TestBase<T> {
+class TrianglePSylv: public flit::TestBase<T> {
 public:
-  TrianglePSylv(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  TrianglePSylv(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.iters = 200;
     ti.vals = { 6.0 };
     return ti;
@@ -67,9 +66,9 @@ public:
 
 protected:
   virtual
-  QFPTest::KernelFunction<T>* getKernel() {return TrianglePSKern; }
+  flit::KernelFunction<T>* getKernel() {return TrianglePSKern; }
   virtual
-  QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     T maxval = ti.vals[0];
     // start as a right triangle
     T a = maxval;
@@ -96,7 +95,7 @@ protected:
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(TrianglePSylv)

--- a/litmus-tests/tests/langois.cpp
+++ b/litmus-tests/tests/langois.cpp
@@ -9,7 +9,6 @@
 #include <cmath>
 #include <tuple>
 
-using namespace QFPHelpers;
 
 //this is a dummy -- needs to be implemented
 //the body of a different algo in CUDA is left
@@ -17,8 +16,7 @@ using namespace QFPHelpers;
 // template <typename T>
 // GLOBAL
 // void
-// addNameHere(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// addNameHere(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -28,19 +26,19 @@ using namespace QFPHelpers;
 //   T maxval = tiList[idx].vals[0];
 //   T a = maxval;
 //   T b = maxval;
-//   T c = maxval * csqrt((T)2.0);
+//   T c = maxval * flit::csqrt((T)2.0);
 //   const T delta = maxval / (T)ti.iters;
 //   const T checkVal = (T)0.5 * b * a;
 
 //   double score = 0.0;
 
 //   for(T pos = 0; pos <= a; pos += delta){
-//     b = csqrt(cpow(pos, (T)2.0) +
-// 	      cpow(maxval, (T)2.0));
-//     c = csqrt(cpow(a - pos, (T)2.0) +
-// 	      cpow(maxval, (T)2.0));
+//     b = flit::csqrt(flit::cpow(pos, (T)2.0) +
+// 	      flit::cpow(maxval, (T)2.0));
+//     c = flit::csqrt(flit::cpow(a - pos, (T)2.0) +
+// 	      flit::cpow(maxval, (T)2.0));
 //     auto crit = getCArea(a,b,c);
-//     score += abs(crit - checkVal);
+//     score += std::abs(crit - checkVal);
 //   }
 //   results[idx].s1 = score;
 //   results[idx].s2 = 0.0;
@@ -76,26 +74,26 @@ ThreeFMA(T a, T b, T c, T& x, T& y, T& z){
   TwoSum(u1, a1, B1, B2);
   y = (B1 - x) + B2;
 }
-}
+} // end of unnamed namespace
 
 //algorithm 11
 template <typename T>
-class langDotFMA: public QFPTest::TestBase<T> {
+class langDotFMA: public flit::TestBase<T> {
 public:
-  langDotFMA(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  langDotFMA(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 0; }
-  virtual QFPTest::TestInput<T> getDefaultInput() { return {}; }
+  virtual flit::TestInput<T> getDefaultInput() { return {}; }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     Q_UNUSED(ti);
     using stype = typename std::vector<T>::size_type;
     stype size = 16;
-    auto rand = getRandSeq<T>();
+    auto rand = flit::getRandSeq<T>();
     auto x = std::vector<T>(rand.begin(),
 			    rand.begin() + size);
     auto y = std::vector<T>(rand.begin() + size,
@@ -109,29 +107,29 @@ protected:
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(langDotFMA)
 
 //algorithm 12
 template <typename T>
-class langCompDotFMA: public QFPTest::TestBase<T> {
+class langCompDotFMA: public flit::TestBase<T> {
 public:
-  langCompDotFMA(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  langCompDotFMA(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 0; }
-  virtual QFPTest::TestInput<T> getDefaultInput() { return {}; }
+  virtual flit::TestInput<T> getDefaultInput() { return {}; }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     Q_UNUSED(ti);
     using stype = typename std::vector<T>::size_type;
     stype size = 16;
-    auto rand = getRandSeq<T>();
+    auto rand = flit::getRandSeq<T>();
     auto x = std::vector<T>(rand.begin(),
 			    rand.begin() + size);
     auto y = std::vector<T>(rand.begin() + size,
@@ -148,29 +146,29 @@ protected:
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(langCompDotFMA)
 
 //algorithm 13
 template <typename T>
-class langCompDot: public QFPTest::TestBase<T> {
+class langCompDot: public flit::TestBase<T> {
 public:
-  langCompDot(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  langCompDot(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   virtual size_t getInputsPerRun() { return 0; }
-  virtual QFPTest::TestInput<T> getDefaultInput() { return {}; }
+  virtual flit::TestInput<T> getDefaultInput() { return {}; }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     Q_UNUSED(ti);
     using stype = typename std::vector<T>::size_type;
     stype size = 16;
-    auto rand = getRandSeq<T>();
+    auto rand = flit::getRandSeq<T>();
     auto x = std::vector<T>(rand.begin(),
 			    rand.begin() + size);
     auto y = std::vector<T>(rand.begin() + size,
@@ -188,7 +186,7 @@ protected:
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(langCompDot)

--- a/litmus-tests/tests/tinys.cpp
+++ b/litmus-tests/tests/tinys.cpp
@@ -8,13 +8,11 @@
 #include <iomanip>
 #include <type_traits>
 
-using namespace QFPHelpers;
 
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -25,22 +23,22 @@ using namespace QFPHelpers;
 // }
 
 template <typename T>
-class FtoDecToF: public QFPTest::TestBase<T> {
+class FtoDecToF: public flit::TestBase<T> {
 public:
-  FtoDecToF(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  FtoDecToF(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-  QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+  flit::TestInput<T> ti;
     ti.vals = {std::nextafter(T(0.0), T(1.0))};
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     std::numeric_limits<T> nlim;
     // from https://en.wikipedia.org/wiki/IEEE_floating_point
     uint16_t ddigs = nlim.digits * std::log10(2) + 1;
@@ -53,7 +51,7 @@ protected:
     return{std::pair<long double, long double>(std::fabs((long double)ti.vals[0] - backAgain), 0.0), 0};
   }
 
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(FtoDecToF)
@@ -61,8 +59,7 @@ REGISTER_TYPE(FtoDecToF)
 // template <typename T>
 // GLOBAL
 // void
-// subnormalKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// subnormalKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -73,26 +70,26 @@ REGISTER_TYPE(FtoDecToF)
 // }
 
 template <typename T>
-class subnormal: public QFPTest::TestBase<T> {
+class subnormal: public flit::TestBase<T> {
 public:
-  subnormal(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  subnormal(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = {std::nextafter(T(0.0), T(1.0))};
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     return {
       std::pair<long double, long double>(ti.vals[0] - ti.vals[0] / 2, 0.0), 0
     };
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(subnormal)
@@ -100,8 +97,7 @@ REGISTER_TYPE(subnormal)
 // template <typename T>
 // GLOBAL
 // void
-// dotProdKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// dotProdKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -112,38 +108,37 @@ REGISTER_TYPE(subnormal)
 // }
 
 template <typename T>
-class dotProd: public QFPTest::TestBase<T> {
+class dotProd: public flit::TestBase<T> {
 public:
-  dotProd(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  dotProd(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 0; }
-  virtual QFPTest::TestInput<T> getDefaultInput() { return {}; }
+  virtual flit::TestInput<T> getDefaultInput() { return {}; }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     Q_UNUSED(ti);
     auto size = 16;
 
-    auto rand = getRandSeq<T>();
+    auto rand = flit::getRandSeq<T>();
 
-    Vector<T> A(std::vector<T>(rand.begin(),
+    flit::Vector<T> A(std::vector<T>(rand.begin(),
 			    rand.begin() + size));
-    Vector<T> B(std::vector<T>(rand.begin() + size,
+    flit::Vector<T> B(std::vector<T>(rand.begin() + size,
 			    rand.begin() + 2*size));
     return {std::pair<long double, long double>(A ^ B, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(dotProd)
 
 // template <typename T>
 // GLOBAL
 // void
-// simpleReductionKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// simpleReductionKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -154,20 +149,20 @@ REGISTER_TYPE(dotProd)
 // }
 
 template <typename T>
-class simpleReduction: public QFPTest::TestBase<T> {
+class simpleReduction: public flit::TestBase<T> {
 public:
-  simpleReduction(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  simpleReduction(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 0; }
-  virtual QFPTest::TestInput<T> getDefaultInput() { return {}; }
+  virtual flit::TestInput<T> getDefaultInput() { return {}; }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     Q_UNUSED(ti);
-    auto vals = getRandSeq<T>();
+    auto vals = flit::getRandSeq<T>();
     auto sublen = vals.size() / 4 - 1;
     T sum = 0;
     for(uint32_t i = 0; i < sublen; i += 4){
@@ -181,7 +176,7 @@ protected:
     }
     return {std::pair<long double, long double>((long double) sum, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(simpleReduction)
 
@@ -190,8 +185,7 @@ REGISTER_TYPE(simpleReduction)
 // template <typename T>
 // GLOBAL
 // void
-// addTOLKernel(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// addTOLKernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -202,13 +196,13 @@ REGISTER_TYPE(simpleReduction)
 // }
 
 template <typename T>
-class addTOL : public QFPTest::TestBase<T> {
+class addTOL : public flit::TestBase<T> {
 public:
-  addTOL(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  addTOL(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
     std::numeric_limits<T> nls;
     auto man_bits = nls.digits;
     std::mt19937 gen(1);
@@ -220,31 +214,31 @@ public:
     //for the ldexp function we're using, it takes an unbiased exponent and
     //there is no implied 1 MSB for the mantissa / significand
     T zero = 0.0;
-    auto L1m = as_int(zero);
-    auto L2m = as_int(zero);
-    auto sm = as_int(zero);
+    auto L1m = flit::as_int(zero);
+    auto L2m = flit::as_int(zero);
+    auto sm = flit::as_int(zero);
     for(int i = 0; i < man_bits; ++i){
       L1m &= (gen() & 1) << i;
       L2m &= (gen() & 1) << i;
       sm  &= (gen() & 1) << i;
     }
     ti.vals = {
-      std::ldexp(as_float(L1m), L1e),
-      std::ldexp(as_float(L2m), L1e - 1),
-      std::ldexp(as_float(sm), L1e - man_bits)
+      std::ldexp(flit::as_float(L1m), L1e),
+      std::ldexp(flit::as_float(L2m), L1e - 1),
+      std::ldexp(flit::as_float(sm), L1e - man_bits)
     };
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] + ti.vals[1] + ti.vals[2];
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 //the basic idea of this test is A(I) + B + TOL, where A & B are large,
@@ -254,8 +248,7 @@ REGISTER_TYPE(addTOL)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -266,36 +259,35 @@ REGISTER_TYPE(addTOL)
 // }
 
 template <typename T>
-class addSub: public QFPTest::TestBase<T> {
+class addSub: public flit::TestBase<T> {
 public:
-  addSub(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  addSub(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
     ti.vals = {T(1.0)};
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     std::numeric_limits<T> nls;
     auto man_bits = nls.digits;
     auto big = std::pow(2, (T)man_bits - 1);
     auto res = (ti.vals[0] + big) - big;
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(addSub)
 
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -306,36 +298,35 @@ REGISTER_TYPE(addSub)
 // }
 
 template <typename T>
-class divc: public QFPTest::TestBase<T> {
+class divc: public flit::TestBase<T> {
 public:
-  divc(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  divc(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 2; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      getRandSeq<T>()[1],
+      flit::getRandSeq<T>()[0],
+      flit::getRandSeq<T>()[1],
     };
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] / ti.vals[1];
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(divc)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -346,34 +337,33 @@ REGISTER_TYPE(divc)
 // }
 
 template <typename T>
-class zeroMinusX: public QFPTest::TestBase<T> {
+class zeroMinusX: public flit::TestBase<T> {
 public:
-  zeroMinusX(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  zeroMinusX(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
-    ti.vals = { getRandSeq<T>()[0] };
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
+    ti.vals = { flit::getRandSeq<T>()[0] };
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = T(0.0) - ti.vals[0];
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(zeroMinusX)
 
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -384,34 +374,33 @@ REGISTER_TYPE(zeroMinusX)
 // }
 
 template <typename T>
-class xMinusZero: public QFPTest::TestBase<T> {
+class xMinusZero: public flit::TestBase<T> {
 public:
-  xMinusZero(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  xMinusZero(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
-    ti.vals = { getRandSeq<T>()[0] };
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
+    ti.vals = { flit::getRandSeq<T>()[0] };
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] - (T)0.0;
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(xMinusZero)
 
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -422,33 +411,32 @@ REGISTER_TYPE(xMinusZero)
 // }
 
 template <typename T>
-class zeroDivX: public QFPTest::TestBase<T> {
+class zeroDivX: public flit::TestBase<T> {
 public:
-  zeroDivX(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  zeroDivX(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
-    ti.vals = { getRandSeq<T>()[0] };
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
+    ti.vals = { flit::getRandSeq<T>()[0] };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = (T)0.0 / ti.vals[0];
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(zeroDivX)
 
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -459,33 +447,32 @@ REGISTER_TYPE(zeroDivX)
 // }
 
 template <typename T>
-class xDivOne: public QFPTest::TestBase<T> {
+class xDivOne: public flit::TestBase<T> {
 public:
-  xDivOne(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  xDivOne(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
-    ti.vals = { getRandSeq<T>()[0] };
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
+    ti.vals = { flit::getRandSeq<T>()[0] };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] / (T)1.0;
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(xDivOne)
 
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -496,33 +483,32 @@ REGISTER_TYPE(xDivOne)
 // }
 
 template <typename T>
-class xDivNegOne: public QFPTest::TestBase<T> {
+class xDivNegOne: public flit::TestBase<T> {
 public:
-  xDivNegOne(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  xDivNegOne(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
-    ti.vals = { getRandSeq<T>()[0] };
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
+    ti.vals = { flit::getRandSeq<T>()[0] };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] / (T)-1.0;
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(xDivNegOne)
 
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -533,36 +519,35 @@ REGISTER_TYPE(xDivNegOne)
 // }
 
 template <typename T>
-class negAdivB: public QFPTest::TestBase<T> {
+class negAdivB: public flit::TestBase<T> {
 public:
-  negAdivB(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  negAdivB(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 2; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      getRandSeq<T>()[1],
+      flit::getRandSeq<T>()[0],
+      flit::getRandSeq<T>()[1],
     };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = -(ti.vals[0] / ti.vals[1]);
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(negAdivB)
 
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -573,26 +558,26 @@ REGISTER_TYPE(negAdivB)
 // }
 
 // template <typename T>
-// class twiceCast: public QFPTest::TestBase<T> {
+// class twiceCast: public flit::TestBase<T> {
 // public:
-//   twiceCast(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+//   twiceCast(std::string id) : flit::TestBase<T>(std::move(id)){}
 
 //   virtual size_t getInputsPerRun() { return 1; }
-//   virtual QFPTest::TestInput<T> getDefaultInput(){
-//     QFPTest::TestInput<T> ti;
-//     ti.vals = { getRandSeq<T>()[0] };
+//   virtual flit::TestInput<T> getDefaultInput(){
+//     flit::TestInput<T> ti;
+//     ti.vals = { flit::getRandSeq<T>()[0] };
 //     return ti;
 //   }
 // protected:
-//   virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+//   virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 // 
-//   virtual QFPTest::ResultType::mapped_type
-//   run_impl(const QFPTest::TestInput<T>& ti) {
+//   virtual flit::ResultType::mapped_type
+//   run_impl(const flit::TestInput<T>& ti) {
 //     //yes, this is ugly.  ti.vals s/b vector of floats
 //     auto res = (T)((std::result_of<::get_next_type(T)>::type)ti.vals[0]);
 //     return {res, 0.0};
 //   }
-//   using QFPTest::TestBase<T>::id;
+//   using flit::TestBase<T>::id;
 // };
 // REGISTER_TYPE(twiceCast)
 
@@ -600,8 +585,7 @@ REGISTER_TYPE(negAdivB)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -612,28 +596,28 @@ REGISTER_TYPE(negAdivB)
 // }
 
 template <typename T>
-class negAminB: public QFPTest::TestBase<T> {
+class negAminB: public flit::TestBase<T> {
 public:
-  negAminB(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  negAminB(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 2; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      getRandSeq<T>()[1],
+      flit::getRandSeq<T>()[0],
+      flit::getRandSeq<T>()[1],
     };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = -(ti.vals[0] - ti.vals[1]);
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(negAminB)
 
@@ -641,8 +625,7 @@ REGISTER_TYPE(negAminB)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -653,26 +636,26 @@ REGISTER_TYPE(negAminB)
 // }
 
 template <typename T>
-class xMinusX: public QFPTest::TestBase<T> {
+class xMinusX: public flit::TestBase<T> {
 public:
-  xMinusX(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  xMinusX(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 1; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
-    ti.vals = { getRandSeq<T>()[0] };
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
+    ti.vals = { flit::getRandSeq<T>()[0] };
     return ti;
   }
 
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] - ti.vals[0];
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(xMinusX)
 
@@ -680,8 +663,7 @@ REGISTER_TYPE(xMinusX)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -692,28 +674,28 @@ REGISTER_TYPE(xMinusX)
 // }
 
 template <typename T>
-class negAplusB: public QFPTest::TestBase<T> {
+class negAplusB: public flit::TestBase<T> {
 public:
-  negAplusB(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  negAplusB(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 2; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      getRandSeq<T>()[1],
+      flit::getRandSeq<T>()[0],
+      flit::getRandSeq<T>()[1],
     };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = -(ti.vals[0] + ti.vals[1]);
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(negAplusB)
 
@@ -721,8 +703,7 @@ REGISTER_TYPE(negAplusB)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -733,29 +714,29 @@ REGISTER_TYPE(negAplusB)
 // }
 
 template <typename T>
-class aXbDivC: public QFPTest::TestBase<T> {
+class aXbDivC: public flit::TestBase<T> {
 public:
-  aXbDivC(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  aXbDivC(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      getRandSeq<T>()[1],
-      getRandSeq<T>()[2],
+      flit::getRandSeq<T>()[0],
+      flit::getRandSeq<T>()[1],
+      flit::getRandSeq<T>()[2],
     };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] * (ti.vals[1] / ti.vals[2]);
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(aXbDivC)
 
@@ -763,8 +744,7 @@ REGISTER_TYPE(aXbDivC)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -775,29 +755,29 @@ REGISTER_TYPE(aXbDivC)
 // }
 
 template <typename T>
-class aXbXc: public QFPTest::TestBase<T> {
+class aXbXc: public flit::TestBase<T> {
 public:
-  aXbXc(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  aXbXc(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      getRandSeq<T>()[1],
-      getRandSeq<T>()[2],
+      flit::getRandSeq<T>()[0],
+      flit::getRandSeq<T>()[1],
+      flit::getRandSeq<T>()[2],
     };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] * (ti.vals[1] * ti.vals[2]);
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(aXbXc)
 
@@ -805,8 +785,7 @@ REGISTER_TYPE(aXbXc)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -817,29 +796,29 @@ REGISTER_TYPE(aXbXc)
 // }
 
 template <typename T>
-class aPbPc: public QFPTest::TestBase<T> {
+class aPbPc: public flit::TestBase<T> {
 public:
-  aPbPc(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  aPbPc(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      getRandSeq<T>()[1],
-      getRandSeq<T>()[2],
+      flit::getRandSeq<T>()[0],
+      flit::getRandSeq<T>()[1],
+      flit::getRandSeq<T>()[2],
     };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] + (ti.vals[1] + ti.vals[2]);
     return {std::pair<long double, long double>(res, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(aPbPc)
 
@@ -847,8 +826,7 @@ REGISTER_TYPE(aPbPc)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -859,29 +837,29 @@ REGISTER_TYPE(aPbPc)
 // }
 
 template <typename T>
-class xPc1EqC2: public QFPTest::TestBase<T> {
+class xPc1EqC2: public flit::TestBase<T> {
 public:
-  xPc1EqC2(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  xPc1EqC2(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      get_tiny1<T>(),
-      get_tiny2<T>(),
+      flit::getRandSeq<T>()[0],
+      flit::get_tiny1<T>(),
+      flit::get_tiny2<T>(),
     };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] + ti.vals[1] == ti.vals[2];
     return {std::pair<long double, long double>(res?1.0:0.0, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(xPc1EqC2)
 
@@ -889,8 +867,7 @@ REGISTER_TYPE(xPc1EqC2)
 // template <typename T>
 // GLOBAL
 // void
-// FtoDecToFKern(const QFPTest::CuTestInput<T>* tiList, QFPTest::CudaResultElement* results){
-//   using namespace CUHelpers;
+// FtoDecToFKern(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results){
 // #ifdef __CUDA__
 //   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 // #else
@@ -901,28 +878,28 @@ REGISTER_TYPE(xPc1EqC2)
 // }
 
 template <typename T>
-class xPc1NeqC2: public QFPTest::TestBase<T> {
+class xPc1NeqC2: public flit::TestBase<T> {
 public:
-  xPc1NeqC2(std::string id) : QFPTest::TestBase<T>(std::move(id)){}
+  xPc1NeqC2(std::string id) : flit::TestBase<T>(std::move(id)){}
 
   virtual size_t getInputsPerRun() { return 3; }
-  virtual QFPTest::TestInput<T> getDefaultInput(){
-    QFPTest::TestInput<T> ti;
+  virtual flit::TestInput<T> getDefaultInput(){
+    flit::TestInput<T> ti;
     ti.vals = {
-      getRandSeq<T>()[0],
-      get_tiny1<T>(),
-      get_tiny2<T>(),
+      flit::getRandSeq<T>()[0],
+      flit::get_tiny1<T>(),
+      flit::get_tiny2<T>(),
     };
     return ti;
   }
 protected:
-  virtual QFPTest::KernelFunction<T>* getKernel() { return nullptr; }
+  virtual flit::KernelFunction<T>* getKernel() { return nullptr; }
 
-  virtual QFPTest::ResultType::mapped_type
-  run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type
+  run_impl(const flit::TestInput<T>& ti) {
     auto res = ti.vals[0] + ti.vals[1] != ti.vals[2];
     return {std::pair<long double, long double>(res?1.0:0.0, 0.0), 0};
   }
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 REGISTER_TYPE(xPc1NeqC2)

--- a/scripts/flitcli/data/tests/Empty.cpp
+++ b/scripts/flitcli/data/tests/Empty.cpp
@@ -8,9 +8,9 @@
  * getInputsPerRun(), getDefaultInput() and run_impl().
  */
 template <typename T>
-class Empty : public QFPTest::TestBase<T> {
+class Empty : public flit::TestBase<T> {
 public:
-  Empty(std::string id) : QFPTest::TestBase<T>(std::move(id)) {}
+  Empty(std::string id) : flit::TestBase<T>(std::move(id)) {}
 
   /** Specify how many floating-point inputs your algorithm takes.
    * 
@@ -28,8 +28,8 @@ public:
    * If your algorithm takes no inputs, then you can simply return an empty
    * TestInput object.  It is as simple as "return {};".
    */
-  QFPTest::TestInput<T> getDefaultInput() {
-    QFPTest::TestInput<T> ti;
+  flit::TestInput<T> getDefaultInput() {
+    flit::TestInput<T> ti;
     ti.vals = { 1.0 };
     return ti;
   }
@@ -45,12 +45,12 @@ protected:
    * You are guarenteed that ti will have exactly getInputsPerRun() inputs in
    * it.  If getInputsPerRun() returns zero, then ti.vals will be empty.
    */
-  virtual QFPTest::ResultType::mapped_type run_impl(const QFPTest::TestInput<T>& ti) {
+  virtual flit::ResultType::mapped_type run_impl(const flit::TestInput<T>& ti) {
     return {std::pair<long double, long double>(ti.vals[0], 0.0), 0};
   }
 
 protected:
-  using QFPTest::TestBase<T>::id;
+  using flit::TestBase<T>::id;
 };
 
 REGISTER_TYPE(Empty)

--- a/scripts/flitcli/data/tests/Empty.cpp
+++ b/scripts/flitcli/data/tests/Empty.cpp
@@ -2,6 +2,19 @@
 
 #include <string>
 
+template <typename T>
+GLOBAL
+void Empty_kernel(const flit::CuTestInput<T>* tiList, flit::CudaResultElement* results) {
+#ifdef __CUDA__
+  auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+#else
+  auto idx = 0;
+#endif
+  auto& ti = tiList[idx];
+  results[idx].s1 = ti.vals[0];
+  results[idx].s2 = 0.0;
+}
+
 /** An example test class to show how to make FLiT tests
  *
  * You will want to rename this file and rename the class.  Then implement
@@ -35,6 +48,19 @@ public:
   }
 
 protected:
+  /** Return a kernel pointer to the CUDA kernel equivalent of run_impl
+   *
+   * The default base implementation of this function is simply to return
+   * null_ptr, which will cause it to call run_impl even when compiled under
+   * CUDA.
+   *
+   * If you do not have or do not want to have a CUDA version of your code,
+   * then you can delete this virtual function and use the base implementation.
+   *
+   * See the documentation above Empty_kernel() for details about what the
+   * kernel is expected to have.
+   */
+  virtual flit::KernelFunction<T>* getKernel() { return Empty_kernel; }
 
   /** Call or implement the algorithm here.
    *

--- a/src/CUHelpers.cpp
+++ b/src/CUHelpers.cpp
@@ -1,61 +1,22 @@
-//#ifdef __CUDA__
-//#include <cuda.h>
 #include "CUHelpers.hpp"
 #include "QFPHelpers.hpp"
-#ifdef __CUDA__
-#include <helper_cuda.h>
-#endif
 
-namespace CUHelpers {
+namespace flit {
 
-#ifdef __CPUKERNEL__
-  const float* cuda_float_rands = QFPHelpers::float_rands.data();
-  const uint_fast32_t* cuda_16_shuffle = QFPHelpers::shuffled_16.data();
-#else
-DEVICE
-float* cuda_float_rands;
-DEVICE
-uint_fast32_t* cuda_16_shuffle;
-#endif
+DEVICE float* cuda_float_rands;
+DEVICE uint_fast32_t* cuda_16_shuffle;
 
 DEVICE
-const float* getRandSeqCU(){return cuda_float_rands;}
+const float* getRandSeqCU() { return cuda_float_rands; }
 
 DEVICE
-const uint_fast32_t* get16ShuffledCU(){return cuda_16_shuffle;}
+const uint_fast32_t* get16ShuffledCU() { return cuda_16_shuffle; }
 
 GLOBAL
 void
-loadDeviceData(float* fsource, uint_fast32_t* ssource){
+loadDeviceData(float* fsource, uint_fast32_t* ssource) {
   cuda_float_rands = fsource;
   cuda_16_shuffle = ssource;
 }
 
-void
-initDeviceData(){
-#if defined( __CUDA__ ) && !defined( __CPUKERNEL__)
-  auto fsize = sizeof(float) * QFPHelpers::float_rands.size();
-  auto ssize = sizeof(uint_fast32_t) * QFPHelpers::shuffled_16.size();
-  float* tfloat;
-  uint_fast32_t* ssource;
-  checkCudaErrors(cudaMalloc(&tfloat,
-			       fsize)); 
-  checkCudaErrors(cudaMemcpy(tfloat,
-             QFPHelpers::float_rands.data(),
-             fsize,
-			     cudaMemcpyHostToDevice));
-  checkCudaErrors(cudaMalloc(&ssource,
-			       ssize)); 
-  checkCudaErrors(cudaMemcpy(ssource,
-             QFPHelpers::shuffled_16.data(),
-             ssize,
-			     cudaMemcpyHostToDevice));
-  loadDeviceData<<<1,1>>>(tfloat, ssource);
-  checkCudaErrors(cudaDeviceSynchronize());
-#endif
-  
-}
-
-}
-
-//#endif
+} // end of namespace flit

--- a/src/CUHelpers.hpp
+++ b/src/CUHelpers.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef CU_HELPERS_HPP
+#define CU_HELPERS_HPP
 
 #if defined(__CPUKERNEL__) || !defined( __CUDA__)
 #define HOST_DEVICE
@@ -16,8 +17,9 @@
 #include "QFPHelpers.hpp"
 #include "CUVector.hpp"
 
-namespace CUHelpers{
+namespace flit {
 
+// TODO: test out trying to replace csqrt() with std::sqrt()
 template <typename T>
 T
 csqrt(T /*val*/){ return 0; }
@@ -100,6 +102,34 @@ abs(T val){
   else return val * (T)-1;
 }
 
+inline void
+initDeviceData() {
+#ifdef __CPUKERNEL__
+  cuda_float_rands = flit::float_rands.data();
+  cuda_16_shuffle = flit::shuffled_16.data();
+#endif // __CPUKERNEL__
+#if defined(__CUDA__) && !defined(__CPUKERNEL__)
+  auto fsize = sizeof(float) * flit::float_rands.size();
+  auto ssize = sizeof(uint_fast32_t) * flit::shuffled_16.size();
+  float* tfloat;
+  uint_fast32_t* ssource;
+  checkCudaErrors(cudaMalloc(&tfloat,
+             fsize));
+  checkCudaErrors(cudaMemcpy(tfloat,
+             flit::float_rands.data(),
+             fsize,
+             cudaMemcpyHostToDevice));
+  checkCudaErrors(cudaMalloc(&ssource,
+             ssize));
+  checkCudaErrors(cudaMemcpy(ssource,
+             flit::shuffled_16.data(),
+             ssize,
+             cudaMemcpyHostToDevice));
+  loadDeviceData<<<1,1>>>(tfloat, ssource);
+  checkCudaErrors(cudaDeviceSynchronize());
+#endif // defined(__CUDA__) && !defined(__CPUKERNEL__)
+}
+
 template <typename T>
 class MatrixCU;
 
@@ -146,7 +176,7 @@ public:
     return data.size();
   }
 
-  DEVICE  
+  DEVICE
   static
   VectorCU<T>
   getRandomVector(vsize_t dim){
@@ -183,14 +213,14 @@ public:
     return t * (*this);
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   VectorCU<T>
   getUnitVector() const {
     VectorCU<T> retVal(*this);
     return retVal * ((T)1.0 / (L2Norm()));
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   bool
   operator==(VectorCU<T> const &b){
     if(this->data.size() != b.data.size()) return false;
@@ -200,7 +230,7 @@ public:
     return true;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   T
   L1Distance(VectorCU<T> const &rhs) const {
     T distance = 0;
@@ -210,7 +240,7 @@ public:
     return distance;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   T
   operator^(VectorCU<T> const &rhs) const {
     T sum = 0.0;
@@ -220,7 +250,7 @@ public:
     return sum;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   VectorCU<T>
   operator*(VectorCU<T> const &rhs) const{
     VectorCU<T> ret(data.size());
@@ -252,7 +282,7 @@ public:
     return retVal;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   T
   LInfNorm() const {
     T largest = 0;
@@ -265,7 +295,7 @@ public:
     return largest;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   T
   LInfDistance(VectorCU<T> const &rhs) const {
     auto diff = operator-(rhs);
@@ -274,7 +304,7 @@ public:
 
   //TODO this assumes there is only float and double on
   //CUDA (may change for half precision)
-  HOST_DEVICE  
+  HOST_DEVICE
   T
   L2Norm() const {
     VectorCU<T> squares = (*this) * (*this);
@@ -287,12 +317,12 @@ public:
   }
 
   T
-  HOST_DEVICE  
+  HOST_DEVICE
   L2Distance(VectorCU<T> const &rhs) const {
     return ((*this) - rhs).L2Norm();
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   VectorCU<T>
   cross(VectorCU<T> const &rhs) const {
     VectorCU<T> retVal(data.size());
@@ -302,7 +332,7 @@ public:
     return retVal;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   bool
   isOrtho(VectorCU<T> const &rhs){
     return operator^(rhs) == (T)0;
@@ -310,13 +340,13 @@ public:
 };
 
 template<typename T>
-class MatrixCU{
+class MatrixCU {
   using rdtype = cuvector<T>;
   cuvector<rdtype> data;
 public:
   using vsize_t = typename cuvector<T>::cvs_t;
 
-  HOST_DEVICE  
+  HOST_DEVICE
   MatrixCU(vsize_t rows, vsize_t cols):
     data(rows, cuvector<T>(cols,0)){}
 
@@ -334,7 +364,7 @@ public:
     return data[indx];
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   bool
   operator==(MatrixCU<T> const &rhs) const {
     if(data.size() != rhs.data.size()) return false;
@@ -350,7 +380,7 @@ public:
     return retVal;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   MatrixCU<T>
   operator*(T const &sca){
     MatrixCU<T> retVal(data.size(), data[0].size());
@@ -359,10 +389,10 @@ public:
         retVal.data[x][y] = data[x][y] * sca;
       }
     }
-    return retVal;    
+    return retVal;
   }
-  
-  HOST_DEVICE  
+
+  HOST_DEVICE
   MatrixCU<T>
   operator*(MatrixCU<T> const &rhs){
     MatrixCU<T> retVal(data.size(), rhs.data[0].size());
@@ -376,7 +406,7 @@ public:
     return retVal;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   static
   MatrixCU<T>
   SkewSymCrossProdM(VectorCU<T> const &v){
@@ -396,7 +426,7 @@ public:
     return retVal;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   static
   MatrixCU<T>
   Identity(size_t dims){
@@ -410,7 +440,7 @@ public:
     return retVal;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   VectorCU<T>
   operator*(VectorCU<T> const &v) const {
     VectorCU<T> retVal((vsize_t)data.size());
@@ -427,7 +457,7 @@ public:
     return retVal;
   }
 
-  HOST_DEVICE  
+  HOST_DEVICE
   MatrixCU<T>
   operator+(MatrixCU<T> const&rhs) const{
     MatrixCU<T> retVal(data.size(), data.size());
@@ -446,8 +476,9 @@ public:
       y = 0; ++x;
     }
     return retVal;
-  }  
+  }
 };
-}
 
-//#endif
+} // end of namespace flit
+
+#endif // CU_HELPERS_HPP

--- a/src/CUHelpers.hpp
+++ b/src/CUHelpers.hpp
@@ -102,6 +102,14 @@ abs(T val){
   else return val * (T)-1;
 }
 
+const std::vector<float> float_rands;
+const std::vector<double> double_rands;
+const std::vector<long double> long_rands;
+const std::vector<uint_fast32_t> shuffled_16;
+
+GLOBAL void loadDeviceData(float* fsource, uint_fast32_t* ssource);
+
+
 inline void
 initDeviceData() {
 #ifdef __CPUKERNEL__

--- a/src/InfoStream.cpp
+++ b/src/InfoStream.cpp
@@ -21,7 +21,7 @@ namespace {
 
   static InfoStreamBackend infoStreamBackendSingleton;
   std::mutex infoStreamMutex;
-}
+} // end of unnamed namespace
 
 InfoStream::InfoStream()
   : std::ostream()

--- a/src/QFPHelpers.cpp
+++ b/src/QFPHelpers.cpp
@@ -54,7 +54,6 @@ get_tiny2<long double>(){
 }
 
   //const std::vector<float> float_rands = setRandSequence<float>(RAND_VECT_SIZE);
-const std::vector<uint_fast32_t> shuffled_16  = getShuffleSeq(16);
 
 template<>
 const std::vector<float>&

--- a/src/QFPHelpers.cpp
+++ b/src/QFPHelpers.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <mutex>
 
-namespace QFPHelpers {
+namespace flit {
 
 const std::vector<uint_fast32_t>
 getShuffleSeq(uint_fast32_t size){
@@ -98,5 +98,5 @@ std::ostream& operator<<(std::ostream& os, const unsigned __int128 i){
   return os;
 }
 
-}
+} // end of namespace flit
  

--- a/src/QFPHelpers.hpp
+++ b/src/QFPHelpers.hpp
@@ -31,7 +31,7 @@
 // #endif
 
 
-namespace QFPHelpers {
+namespace flit {
 
 const int RAND_SEED = 1;
 const int RAND_VECT_SIZE = 256;
@@ -500,7 +500,7 @@ public:
   }
 };
 
-}
+} // end of namespace flit
 
 #endif
  

--- a/src/TestBase.cpp
+++ b/src/TestBase.cpp
@@ -15,8 +15,8 @@
 // std::stack<float> fStack;
 // std::stack<double> dStack;
 // std::stack<long double> lStack;
-// }
-namespace QFPTest{
+// } // end of unnamed namespace
+namespace flit {
 
   //output operator for ResultType
 std::ostream&
@@ -32,4 +32,4 @@ operator<<(std::ostream& os, const ResultType& res){
   }
   return os;
 }
-}
+} // end of namespace flit

--- a/src/TestBase.hpp
+++ b/src/TestBase.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <cassert>
 
-namespace QFPTest {
+namespace flit {
 
 void setWatching(bool watch = true);
 
@@ -420,10 +420,10 @@ inline std::shared_ptr<TestBase<long double>> TestFactory::get<long double> () {
 #ifdef __CUDA__
 
 #define REGISTER_TYPE(klass)                                \
-  class klass##Factory : public QFPTest::TestFactory {      \
+  class klass##Factory : public flit::TestFactory {      \
   public:                                                   \
     klass##Factory() {                                      \
-      QFPTest::registerTest(#klass, this);                  \
+      flit::registerTest(#klass, this);                  \
     }                                                       \
   protected:                                                \
     virtual createType create() {                           \
@@ -431,7 +431,7 @@ inline std::shared_ptr<TestBase<long double>> TestFactory::get<long double> () {
           std::make_shared<klass<float>>(#klass),           \
           std::make_shared<klass<double>>(#klass),          \
           /* empty test for long double */                  \
-          std::make_shared<QFPTest::NullTest<long double>>(#klass) \
+          std::make_shared<flit::NullTest<long double>>(#klass) \
           );                                                \
     }                                                       \
   };                                                        \
@@ -440,10 +440,10 @@ inline std::shared_ptr<TestBase<long double>> TestFactory::get<long double> () {
 #else // not __CUDA__
 
 #define REGISTER_TYPE(klass)                                \
-  class klass##Factory : public QFPTest::TestFactory {      \
+  class klass##Factory : public flit::TestFactory {      \
   public:                                                   \
     klass##Factory() {                                      \
-      QFPTest::registerTest(#klass, this);                  \
+      flit::registerTest(#klass, this);                  \
     }                                                       \
   protected:                                                \
     virtual createType create() {                           \
@@ -477,6 +477,6 @@ inline void registerTest(const std::string& name, TestFactory *factory) {
   getTests()[name] = factory;
 }
 
-} // end namespace QFPTest
+} // end namespace flit
 
 #endif // TEST_BASE_HPP

--- a/src/TestBase.hpp
+++ b/src/TestBase.hpp
@@ -368,7 +368,7 @@ public:
   virtual size_t getInputsPerRun() { return 0; }
   virtual ResultType run(const TestInput<T>&,
                          const bool,
-                         const bool) { return {}; }
+                         const size_t) { return {}; }
 protected:
   virtual KernelFunction<T>* getKernel() { return nullptr; }
   virtual ResultType::mapped_type run_impl(const TestInput<T>&) { return {}; }

--- a/src/flit.cpp
+++ b/src/flit.cpp
@@ -13,9 +13,9 @@
 #include "QFPHelpers.hpp"
 #include "TestBase.hpp"
 
-void outputResults(const QFPTest::ResultType& scores){
-  using QFPHelpers::operator<<;
-  using QFPHelpers::as_int;
+void outputResults(const flit::ResultType& scores){
+  using flit::operator<<;
+  using flit::as_int;
   for(const auto& i: scores){
     std::cout
       << "HOST,SWITCHES,OPTL,COMPILER,"
@@ -60,7 +60,7 @@ FlitOptions parseArguments(int argCount, char* argList[]) {
   std::vector<std::string> allowedPrecisions = {
     "all", "float", "double", "long double"
   };
-  auto allowedTests = getKeys(QFPTest::getTests());
+  auto allowedTests = getKeys(flit::getTests());
   allowedTests.emplace_back("all");
   for (int i = 1; i < argCount; i++) {
     std::string current(argList[i]);
@@ -100,7 +100,7 @@ FlitOptions parseArguments(int argCount, char* argList[]) {
   }
 
   if (options.tests.size() == 0 || isIn(options.tests, std::string("all"))) {
-    options.tests = getKeys(QFPTest::getTests());
+    options.tests = getKeys(flit::getTests());
   }
 
   return options;

--- a/src/flit.h
+++ b/src/flit.h
@@ -113,7 +113,7 @@ inline int runFlitTests(int argc, char* argv[]) {
   flit::info_stream.precision(1000);
 
 #ifdef __CUDA__
-  CUHelpers::initDeviceData();
+  flit::initDeviceData();
 #endif
 
   flit::ResultType scores;

--- a/src/flit.h
+++ b/src/flit.h
@@ -19,18 +19,18 @@
 #include <type_traits>
 #include <typeinfo>
 
-void outputResults(const QFPTest::ResultType& scores);
+void outputResults(const flit::ResultType& scores);
 
 template <typename F>
-void runTestWithDefaultInput(QFPTest::TestFactory* factory,
-                             QFPTest::ResultType& totScores,
+void runTestWithDefaultInput(flit::TestFactory* factory,
+                             flit::ResultType& totScores,
                              bool shouldTime = true,
                              int timingLoops = 1) {
   auto test = factory->get<F>();
   auto ip = test->getDefaultInput();
   auto scores = test->run(ip, shouldTime, timingLoops);
   totScores.insert(scores.begin(), scores.end());
-  QFPHelpers::info_stream.flushout();
+  flit::info_stream.flushout();
 }
 
 /** Command-line options */
@@ -99,25 +99,25 @@ inline int runFlitTests(int argc, char* argv[]) {
   }
 
   if (options.listTests) {
-    for (auto& test : getKeys(QFPTest::getTests())) {
+    for (auto& test : getKeys(flit::getTests())) {
       std::cout << test << std::endl;
     }
     return 0;
   }
 
   if (options.verbose) {
-    QFPHelpers::info_stream.show();
+    flit::info_stream.show();
   }
 
   std::cout.precision(1000); //set cout to print many decimal places
-  QFPHelpers::info_stream.precision(1000);
+  flit::info_stream.precision(1000);
 
 #ifdef __CUDA__
   CUHelpers::initDeviceData();
 #endif
 
-  QFPTest::ResultType scores;
-  auto testMap = QFPTest::getTests();
+  flit::ResultType scores;
+  auto testMap = flit::getTests();
   for (auto& testName : options.tests) {
     auto factory = testMap[testName];
     if (options.precision == "all" || options.precision == "float") {


### PR DESCRIPTION
Fixes #54 

As part of this change, I removed all cases of "using namespace <anything>" such as "using namespace std".  This pollution of the global namespace is potentially dangerous.