### PR TITLE
Issue75 time plot

### DIFF
--- a/plotting/plot_timing.py
+++ b/plotting/plot_timing.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+import csv
+import sys
+import os
+import argparse
+import matplotlib.pyplot as plt
+import numpy as np
+
+def read_csv(csvfile):
+    '''
+    Reads and returns the csvfile as a list of dictionaries
+    '''
+    rows = []
+    with open(csvfile, 'r') as fin:
+        reader = csv.DictReader(fin)
+        rows = [row for row in reader]
+    return rows
+
+def plot_timing(csvfile, test_names):
+    '''
+    Plots the timing metrics from the csv file and for the given test_names
+    '''
+    rows = read_csv(csvfile)
+    to_x_lab = lambda row: '{0} {1} {2}'.format(row['compiler'], row['optl'], row['switches'])
+    test_data = {}
+    for name in test_names:
+        data = {}
+        data['name'] = name
+        data['rows'] = [row for row in rows
+                        if row['name'] == name
+                        and row['precision'] == 'f'
+                        and (row['optl'] != '-O0' or row['switches'] == '')
+                        ]
+        data['times'] = np.asarray([int(row['nanosec']) for row in data['rows']])
+        data['fastest'] = min(data['times'])
+        data['slowest'] = max(data['times'])
+        data['speedup'] = data['slowest'] / data['times']
+        data['xlab'] = [to_x_lab(row) for row in data['rows']]
+        data['unopt'] = [row['score0'] for row in data['rows']
+                if row['optl'] == '-O0' and row['switches'] == '']
+        assert all([x == data['unopt'][0] for x in data['unopt']]), str(data['unopt'])
+        data['unopt'] = data['unopt'][0]
+        data['iseql'] = [row['score0'] == data['unopt'] for row in data['rows']]
+        test_data[name] = data
+    for name in test_data:
+        print(name, max(test_data[name]['speedup']))
+        print('  slowest', test_data[name]['slowest'])
+        print('  fastest', test_data[name]['fastest'])
+        speedup = test_data[name]['speedup']
+        xlab = test_data[name]['xlab']
+        iseql = test_data[name]['iseql']
+        joint_sort = sorted(zip(xlab, speedup, iseql), key=lambda x: x[1])
+        xlab = [x[0] for x in joint_sort]
+        speedup = [x[1] for x in joint_sort]
+        iseql = [x[2] for x in joint_sort]
+        eql_idxs = [i for i in range(len(iseql)) if iseql[i] is True]
+        not_eql_idxs = [i for i in range(len(iseql)) if iseql[i] is False]
+        eql_speeds = [speedup[i] for i in eql_idxs]
+        not_eql_speeds = [speedup[i] for i in not_eql_idxs]
+
+        plt.figure(num=1, figsize=(12.5,5), dpi=80)
+        plt.plot(speedup)#, label=name)
+        plt.plot(eql_idxs, eql_speeds, 'b.', label='same answer as unoptimized')
+        plt.plot(not_eql_idxs, not_eql_speeds, 'rx', label='different answer than unoptimized')
+        plt.xticks(np.arange(len(xlab)), xlab, rotation='vertical')
+        plt.legend()
+        plt.ylim(ymin=0)
+        plt.ylabel('Speedup from unoptimized')
+        plt.tight_layout()
+        #plt.show()
+        newname = name + '.svg'
+        plt.savefig(newname, format='svg')
+        plt.cla()
+    #fig, ax = plt.subplots()
+    #plt.xticks(np.arange(len(flags)), flags, rotation='vertical')
+    #plt.show()
+    #base = os.path.basename(csvfile)
+    #newname = os.path.splitext(base)[0] + '.svg'
+    #plt.savefig(newname, format='svg', dpi=300)
+
+
+def main(arguments):
+    'Main entry point, calls plot_timing()'
+    parser = argparse.ArgumentParser()
+    parser.add_argument('csv')
+    parser.add_argument('test', nargs='+')
+    args = parser.parse_args(arguments)
+    plot_timing(args.csv, args.test)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/plotting/plot_timing.py
+++ b/plotting/plot_timing.py
@@ -115,7 +115,7 @@ def plot_timing(rows, test_names=[], outdir='.'):
         not_eql_speeds = [speedup[i] for i in not_eql_idxs]
 
         plt.figure(num=1, figsize=(12.5,5), dpi=80)
-        plt.plot(speedup)#, label=name)
+        plt.plot(speedup)
         plt.plot(eql_idxs, eql_speeds, 'b.',
                  label='same answer as ground truth')
         plt.plot(not_eql_idxs, not_eql_speeds, 'rx',
@@ -125,17 +125,9 @@ def plot_timing(rows, test_names=[], outdir='.'):
         plt.ylim(ymin=0)
         plt.ylabel('Speedup from slowest')
         plt.tight_layout()
-        #plt.show()
         newname = '{0}-{1}-{2}.svg'.format(name, host, p)
         plt.savefig(os.path.join(outdir, newname), format='svg')
         plt.cla()
-    #fig, ax = plt.subplots()
-    #plt.xticks(np.arange(len(flags)), flags, rotation='vertical')
-    #plt.show()
-    #base = os.path.basename(csvfile)
-    #newname = os.path.splitext(base)[0] + '.svg'
-    #plt.savefig(newname, format='svg', dpi=300)
-
 
 def main(arguments):
     'Main entry point, calls plot_timing()'


### PR DESCRIPTION
Almost fixes #75.  Timing plots can be generated using this standalone python script.  Some things need to be done before #75 can really be labeled as fixed:

1. Run from `flit analyze` instead of a separate script
2. Add documentation for this feature
3. Add to documentation the added dependencies (i.e. `matplotlib`).

But since it is usable at the moment, and it seems stable, I would say it can be merged into devel.