### PR TITLE
Issue91 flit bisect autodelete

### DIFF
--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -177,6 +177,30 @@ trouble: $(TROUBLE_TARGET_RESULT) $(TROUBLE_TARGET_OUT)
 bisect: $(BISECT_TARGET) $(GT_TARGET)
 bisect: $(BISECT_RESULT) $(BISECT_OUT)
 
+.PHONY: bisect-smallclean bisect-clean bisect-distclean
+clean: bisect-clean
+distclean: bisect-distclean
+bisect-smallclean:
+	rm -f $(BISECT_TARGET)
+	rm -f $(BISECT_OUT)
+	rm -f $(addsuffix *.dat,$(BISECT_OUT))
+	rm -f $(TROUBLE_TARGET)
+	rm -f $(TROUBLE_TARGET_OUT)
+	rm -f $(addsuffix *.dat,$(TROUBLE_TARGET_OUT))
+	rm -f $(TROUBLE_SYMBOLS)
+	rm -f $(SPLIT_OBJ)
+	-rmdir $(BISECT_OBJ_DIR)
+
+bisect-clean: bisect-smallclean
+	rm -f $(TROUBLE_TARGET_OBJ)
+
+bisect-distclean: bisect-clean
+	rm -f bisect.log
+	rm -f $(TROUBLE_TARGET_RESULT)
+	rm -f $(BISECT_RESULT)
+	rm -f $(MAKEFILE)
+	-rmdir $(BISECT_DIR)
+
 $(BISECT_DIR):
 	mkdir -p $(BISECT_DIR)
 

--- a/src/TestBase.h
+++ b/src/TestBase.h
@@ -266,14 +266,25 @@ public:
    *   the test is such that it needs to change the notion of running the test
    *   from only a std::vector of inputs for each result pair.
    *
+   * @param ti Test input vector
+   * @param filebase basename for the result file
+   * @param shouldTime true means we should to timing
+   * @param timingLoops how many times to loop.  A value less than one means
+   *        automatically determine timing loops.
+   * @param timingRepeats how many times to repeat the timing.
+   * @param idx which test to run if it is data driven, zero-based indexing.  A
+   *        value less than one means to run them all.
+   *
+   * @return A vector of test results
+   *
    * @see getInputsPerRun
    */
   virtual std::vector<TestResult> run(const std::vector<T>& ti,
                                       const std::string &filebase,
-                                      const bool shouldTime,
-                                      const int timingLoops,
-                                      const int timingRepeats) {
-    FLIT_UNUSED(timingRepeats);
+                                      const bool shouldTime = true,
+                                      const int timingLoops = -1,
+                                      const int timingRepeats = 3,
+                                      const int idx = -1) {
     using std::chrono::high_resolution_clock;
     using std::chrono::duration;
     using std::chrono::duration_cast;
@@ -326,7 +337,16 @@ public:
     };
     std::vector<TimedResult> resultValues;
 
-    for (size_t i = 0; i < inputSequence.size(); i++) {
+    // Either only do the specified index, or all of them
+    std::vector<size_t> indices;
+    if (idx < 0) {
+      indices.resize(inputSequence.size());
+      std::iota(indices.begin(), indices.end(), 0);
+    } else {
+      indices.push_back(idx);
+    }
+
+    for (auto i : indices) {
       auto& runInput = inputSequence.at(i);
       Variant testResult;
       int_fast64_t timing = 0;


### PR DESCRIPTION
Implement `--delete` to flit bisect.  A few other things were added:

- Test executable: can now specify TestCase_idxN to only run a particular data input
- Add bisect run number to the `auto-bisect.csv` results