### PR TITLE
Issue91 flit bisect buildrace

### DIFF
--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -133,6 +133,10 @@ TROUBLE_OBJ      := $(addprefix \
 BISECT_OBJ       := $(BISECT_GT_OBJ)
 BISECT_OBJ       += $(TROUBLE_OBJ)
 TROUBLE_TARGET_DEPS := $(TROUBLE_TARGET_OBJ:%.o=%.d)
+FPIC_OBJ         := $(addprefix \
+	  $(BISECT_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%.cpp=%_gt_fPIC.o)))
+FPIC_OBJ         := $(addprefix \
+	  $(BISECT_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%.cpp=%_bisect_$(TROUBLE_ID)_fPIC.o)))
 SPLIT_OBJ        := $(addprefix \
 	  $(BISECT_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%.cpp=%_gt_split_$(NUMBER).o)))
 SPLIT_OBJ        += $(addprefix \
@@ -189,6 +193,7 @@ bisect-smallclean:
 	rm -f $(addsuffix *.dat,$(TROUBLE_TARGET_OUT))
 	rm -f $(TROUBLE_SYMBOLS)
 	rm -f $(SPLIT_OBJ)
+	rm -f $(FPIC_OBJ)
 	-rmdir $(BISECT_OBJ_DIR)
 
 bisect-clean: bisect-smallclean

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -209,7 +209,7 @@ $(BISECT_OBJ_DIR):
 
 # ground-truth files are already specified in Makefile
 # but need to specify how to do the fPIC variant
-$(OBJ_DIR)/%_gt_fPIC.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
+$(BISECT_OBJ_DIR)/%_gt_fPIC.o: %.cpp Makefile custom.mk | $(BISECT_OBJ_DIR)
 	$(GT_CC) $(GT_OPTL) $(GT_SWITCHES) $(CC_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$(GT_CC)"' \
@@ -228,7 +228,7 @@ $(OBJ_DIR)/%_bisect_$(TROUBLE_ID).o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 	  -DFLIT_FILENAME='"bisect-default-out"'
 
 # and the fPIC variant
-$(OBJ_DIR)/%_bisect_$(TROUBLE_ID)_fPIC.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
+$(BISECT_OBJ_DIR)/%_bisect_$(TROUBLE_ID)_fPIC.o: %.cpp Makefile custom.mk | $(BISECT_OBJ_DIR)
 	$(TROUBLE_CC) $(TROUBLE_OPTL) $(TROUBLE_SWITCHES) $(CC_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$(TROUBLE_CC)"' \
@@ -242,33 +242,33 @@ $(OBJ_DIR)/%_bisect_$(TROUBLE_ID)_fPIC.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 # @param 1: src basename (e.g. for 'tests/Example01.cpp' pass in 'Example01')
 define SPLIT_RULE
 
-$$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(OBJ_DIR)/$1_gt_fPIC.o
+$$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(BISECT_OBJ_DIR)/$1_gt_fPIC.o
 $$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(BISECT_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt
 $$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(MAKEFILE)
 $$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: | $$(BISECT_OBJ_DIR)
 	if [ -s "$$(BISECT_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt" ]; then \
 	  objcopy \
 	    --weaken-symbols=$$(BISECT_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt \
-	    $$(OBJ_DIR)/$1_gt_fPIC.o \
+	    $$(BISECT_OBJ_DIR)/$1_gt_fPIC.o \
 	    $$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o; \
 	else \
 	  cp \
-	    $$(OBJ_DIR)/$1_gt_fPIC.o \
+	    $$(BISECT_OBJ_DIR)/$1_gt_fPIC.o \
 	    $$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o; \
 	fi
 
-$$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o
+$$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(BISECT_OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o
 $$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(MAKEFILE)
 $$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(BISECT_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt
 $$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: | $$(BISECT_OBJ_DIR)
 	if [ -s "$$(BISECT_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt" ]; then \
 	  objcopy \
 	    --weaken-symbols=$$(BISECT_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt \
-	    $$(OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o \
+	    $$(BISECT_OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o \
 	    $$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o; \
 	else \
 	  cp \
-	    $$(OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o \
+	    $$(BISECT_OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o \
 	    $$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o; \
 	fi
 

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -160,7 +160,7 @@ def create_bisect_makefile(directory, replacements, gt_src, trouble_src,
     ready to be executed by 'make bisect' from the top-level directory of the
     user's flit tests.
 
-    @param directory: (str) path where to put the created Makefil
+    @param directory: (str) path where to put the created Makefile
     @param replacements: (dict) key -> value.  The key is found in the
         Makefile_bisect_binary.in and replaced with the corresponding value.
     @param gt_src: (list) which source files would be compiled with the
@@ -896,16 +896,6 @@ def run_bisect(arguments, prog=sys.argv[0]):
 
     update_gt_results(args.directory, verbose=args.verbose, jobs=args.jobs)
 
-    def cleanup_bisect():
-        'Cleanup after this run_bisect() function'
-        if args.delete:
-            build_bisect(
-                os.path.join(bisect_path, 'bisect-make-01.mk'),
-                args.directory,
-                target='bisect-clean',
-                verbose=args.verbose,
-                jobs=args.jobs)
-
     # Find out if the linker is to blame (e.g. intel linker linking mkl libs)
     bad_libs = []
     if os.path.basename(args.compiler) in ('icc', 'icpc'):
@@ -943,7 +933,6 @@ def run_bisect(arguments, prog=sys.argv[0]):
             print()
             print('  Executable failed to run.')
             print('Failed to search for bad libraries -- cannot continue.')
-            cleanup_bisect()
             return bisect_num, None, None, None, 1
 
         print('  bad static libraries:')
@@ -1002,7 +991,6 @@ def run_bisect(arguments, prog=sys.argv[0]):
         print('  Executable failed to run.')
         print('Failed to search for bad sources -- cannot continue.')
         logging.exception('Failed to search for bad sources.')
-        cleanup_bisect()
         return bisect_num, bad_libs, None, None, 1
 
     print('  bad sources:')
@@ -1024,7 +1012,6 @@ def run_bisect(arguments, prog=sys.argv[0]):
         print('  Executable failed to run.')
         print('Failed to search for bad symbols -- cannot continue')
         logging.exception('Failed to search for bad symbols.')
-        cleanup_bisect()
         return bisect_num, bad_libs, bad_sources, None, 1
 
     print('  bad symbols:')
@@ -1038,7 +1025,6 @@ def run_bisect(arguments, prog=sys.argv[0]):
         print('    None')
         logging.info('  None')
 
-    cleanup_bisect()
     return bisect_num, bad_libs, bad_sources, bad_symbols, 0
 
 def auto_bisect_worker(arg_queue, result_queue):

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -188,12 +188,14 @@ def create_bisect_makefile(directory, replacements, gt_src, trouble_src,
     repl_copy['SPLIT_SRC'] = '\n'.join(['SPLIT_SRC        += {0}'.format(x)
                                         for x in split_symbol_map])
     if 'cpp_flags' in repl_copy:
-        repl_copy['EXTRA_CC_FLAGS'] = '\n'.join(['CC_REQUIRED      += {0}'.format(x)
-                                                 for x in repl_copy['cpp_flags']])
+        repl_copy['EXTRA_CC_FLAGS'] = '\n'.join([
+            'CC_REQUIRED      += {0}'.format(x)
+            for x in repl_copy['cpp_flags']])
         del repl_copy['cpp_flags']
     if 'link_flags' in repl_copy:
-        repl_copy['EXTRA_LD_FLAGS'] = '\n'.join(['LD_REQUIRED      += {0}'.format(x)
-                                                 for x in repl_copy['link_flags']])
+        repl_copy['EXTRA_LD_FLAGS'] = '\n'.join([
+            'LD_REQUIRED      += {0}'.format(x)
+            for x in repl_copy['link_flags']])
         del repl_copy['link_flags']
 
 
@@ -317,7 +319,8 @@ def is_result_bad(resultfile):
 
 SymbolTuple = namedtuple('SymbolTuple', 'src, symbol, demangled, fname, lineno')
 SymbolTuple.__doc__ = '''
-Tuple containing information about the symbols in a file.  Has the following attributes:
+Tuple containing information about the symbols in a file.  Has the following
+attributes:
     src:        source file that was compiled
     symbol:     mangled symbol in the compiled version
     demangled:  demangled version of symbol
@@ -374,19 +377,19 @@ def extract_symbols(file_or_filelist, objdir):
     symbol_line_mapping = dict()
     symbol = None
     for line in objdump_strings:
-        if len(line.strip()) == 0:        # skip empty lines
+        if len(line.strip()) == 0:      # skip empty lines
             continue
-        if line[0].isdigit():             # we are at a symbol
+        if line[0].isdigit():           # we are at a symbol
             symbol = line.split()[1][1:-2]
             continue
-        if symbol is None:                # if we don't have an active symbol
-            continue                      # then skip
+        if symbol is None:              # if we don't have an active symbol
+            continue                    # then skip
         srcmatch = re.search(':[0-9]+$', line)
         if srcmatch is not None:
             deffile = line[:srcmatch.start()]
             defline = int(line[srcmatch.start()+1:])
             symbol_line_mapping[symbol] = (deffile, defline)
-            symbol = None                 # deactivate the symbol to not overwrite
+            symbol = None               # deactivate the symbol to not overwrite
 
 
     # generate the symbol tuples
@@ -676,7 +679,8 @@ def search_for_linker_problems(args, bisect_path, replacements, sources, libs):
         for lib in trouble_libs:
             logging.info('  ' + lib)
 
-        build_bisect(makepath, args.directory, verbose=args.verbose, jobs=args.jobs)
+        build_bisect(makepath, args.directory, verbose=args.verbose,
+                     jobs=args.jobs)
         if args.delete:
             build_bisect(makepath, args.directory, target='bisect-smallclean',
                          verbose=args.verbose, jobs=args.jobs)
@@ -726,7 +730,8 @@ def search_for_source_problems(args, bisect_path, replacements, sources):
         for src in trouble_src:
             logging.info('  ' + src)
 
-        build_bisect(makepath, args.directory, verbose=args.verbose, jobs=args.jobs)
+        build_bisect(makepath, args.directory, verbose=args.verbose,
+                     jobs=args.jobs)
         if args.delete:
             build_bisect(makepath, args.directory, target='bisect-smallclean',
                          verbose=args.verbose, jobs=args.jobs)
@@ -747,7 +752,8 @@ def search_for_source_problems(args, bisect_path, replacements, sources):
     bad_sources = bisect_search(bisect_build_and_check, sources)
     return bad_sources
 
-def search_for_symbol_problems(args, bisect_path, replacements, sources, bad_sources):
+def search_for_symbol_problems(args, bisect_path, replacements, sources,
+                               bad_sources):
     '''
     Performs the search over the space of symbols within bad source files for
     problems.
@@ -792,7 +798,8 @@ def search_for_symbol_problems(args, bisect_path, replacements, sources, bad_sou
                 '  {sym.fname}:{sym.lineno} {sym.symbol} -- {sym.demangled}'
                 .format(sym=sym))
 
-        build_bisect(makepath, args.directory, verbose=args.verbose, jobs=args.jobs)
+        build_bisect(makepath, args.directory, verbose=args.verbose,
+                     jobs=args.jobs)
         if args.delete:
             build_bisect(makepath, args.directory, target='bisect-smallclean',
                          verbose=args.verbose, jobs=args.jobs)
@@ -812,7 +819,8 @@ def search_for_symbol_problems(args, bisect_path, replacements, sources, bad_sou
     logging.info('Note: inlining disabled to isolate functions')
     logging.info('Note: only searching over globally exported functions')
     logging.debug('Symbols:')
-    symbol_tuples = extract_symbols(bad_sources, os.path.join(args.directory, 'obj'))
+    symbol_tuples = extract_symbols(bad_sources,
+                                    os.path.join(args.directory, 'obj'))
     for sym in symbol_tuples:
         message = '  {sym.fname}:{sym.lineno} {sym.symbol} -- {sym.demangled}' \
                   .format(sym=sym)

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1223,6 +1223,11 @@ def parallel_auto_bisect(arguments, prog=sys.argv[0]):
         compilation_set = {(row['compiler'], row['optl'], row['switches'])
                            for row in rows}
 
+        # see if the Makefile needs to be regenerated
+        # we use the Makefile to check for itself, sweet
+        subp.check_call(['make', '-C', args.directory, 'Makefile'],
+                        stdout=subp.DEVNULL, stderr=subp.DEVNULL)
+
         print('Before parallel bisect run, compile all object files')
         for compiler, optl, switches in compilation_set:
             print('  ' + ' '.join((compiler, optl, switches)), end='',


### PR DESCRIPTION
Fix the build race when executing parallel bisect

- Multiple instances of bisect under the same compilation but perhaps different tests
  were competing to write and read the same object files
- Those shared object files are no longer cleaned with the `--delete` flag.  They are
  deleted after all is done.
- Move `-fPIC` compiled object files to within the bisect object directory instead of
  the top-level object directory.  This is because we can again contend for the
  creation of these files with parallel bisect invocations.