### PR TITLE
Issue78 rename result columns

### DIFF
--- a/data/db/tables-sqlite.sql
+++ b/data/db/tables-sqlite.sql
@@ -126,8 +126,8 @@ CREATE TABLE IF NOT EXISTS tests (
   optl           varchar,   -- optimization level (e.g. "-O2")
   switches       varchar,   -- compiler flag(s) (e.g. "-ffast-math")
   precision      varchar,   -- precision (f = float, d = double, e = extended)
-  comparison     varchar,   -- metric of comparison - hex value
-  comparison_d   real,      -- metric of comparison of result vs ground truth
+  comparison_hex varchar,   -- metric of comparison - hex value
+  comparison     real,      -- metric of comparison of result vs ground truth
   file           varchar,   -- filename of test executable
   nanosec        integer    check(nanosec >= 0),  -- timing for the function
 

--- a/documentation/database-structure.md
+++ b/documentation/database-structure.md
@@ -42,8 +42,8 @@ CREATE TABLE tests (
   optl           varchar,   -- optimization level (e.g. "-O2")
   switches       varchar,   -- compiler flag(s) (e.g. "-ffast-math")
   precision      varchar,   -- precision (f = float, d = double, e = extended)
-  comparison     varchar,   -- metric of comparison - hex value
-  comparison_d   real,      -- metric of comparison of result vs ground truth
+  comparison_hex varchar,   -- metric of comparison - hex value
+  comparison     real,      -- metric of comparison of result vs ground truth
   file           varchar,   -- filename of test executable
   nanosec        integer    check(nanosec >= 0),  -- timing for the function
 

--- a/documentation/test-executable.md
+++ b/documentation/test-executable.md
@@ -62,7 +62,7 @@ $ flit init --directory flit-litmus --litmus-tests
 $ cd flit-litmus
 $ make dev -j10
 $ ./devrun Paranoia
-name,host,compiler,optl,switches,precision,score,score_d,resultfile,comparison,comparison_d,file,nanosec
+name,host,compiler,optl,switches,precision,score_hex,score,resultfile,comparison_hex,comparison,file,nanosec
 Paranoia,bihexal,g++,-O2,-funsafe-math-optimizations,d,0x4002a000000000000000,10,NULL,NULL,NULL,devrun,1000028414
 Paranoia,bihexal,g++,-O2,-funsafe-math-optimizations,e,0x4002a000000000000000,10,NULL,NULL,NULL,devrun,1000030686
 Paranoia,bihexal,g++,-O2,-funsafe-math-optimizations,f,0x4002a000000000000000,10,NULL,NULL,NULL,devrun,1000043012
@@ -133,7 +133,7 @@ In the following example, the TrianglePHeron example is executed only for 32-bit
 
 ```bash
 $ ./devrun --precision float TrianglePHeron
-name,host,compiler,optl,switches,precision,score,score_d,resultfile,comparison,comparison_d,file,nanosec
+name,host,compiler,optl,switches,precision,score_hex,score,resultfile,comparison_hex,comparison,file,nanosec
 TrianglePHeron,bihexal,g++,-O2,-funsafe-math-optimizations,f,0x3ff3e400000000000000,0.00043487548828125,NULL,NULL,NULL,devrun,6137
 ```
 
@@ -150,7 +150,7 @@ $ ./devrun --no-timing --verbose --precision double SinInt
 SinInt: score       = 1
 SinInt: score - 1.0 = 0
 SinInt-d: # runs = 1
-name,host,compiler,optl,switches,precision,score,score_d,resultfile,comparison,comparison_d,file,nanosec
+name,host,compiler,optl,switches,precision,score_hex,score,resultfile,comparison_hex,comparison,file,nanosec
 SinInt,bihexal,g++,-O2,-funsafe-math-optimizations,d,0x3fff8000000000000000,1,NULL,NULL,NULL,devrun,0
 ```
 

--- a/plotting/plot_speedup_histogram.py
+++ b/plotting/plot_speedup_histogram.py
@@ -119,7 +119,7 @@ def calc_speedups(rows, test_names, baseline=None):
     @return (safe_speedups, unsafe_speedups)
     
     - safe_speedups: (dict{compiler -> list[speedup for test_name i]})
-      Safe speedups, defined by row['comparison_d'] == 0.0
+      Safe speedups, defined by row['comparison'] == 0.0
     - unsafe_speedups: (dist{compiler -> list[speedup for test_name i]})
       Unsafe speedups, defined by not safe.
 
@@ -150,9 +150,9 @@ def calc_speedups(rows, test_names, baseline=None):
         for compiler in compilers:
             compiler_rows = compiler_row_map[compiler]
             safe_times = [int(x['nanosec']) for x in compiler_rows 
-                          if float(x['comparison_d']) == 0.0]
+                          if float(x['comparison']) == 0.0]
             unsafe_times = [int(x['nanosec']) for x in compiler_rows 
-                            if float(x['comparison_d']) != 0.0]
+                            if float(x['comparison']) != 0.0]
 
             if len(safe_times) > 0:
                 safe_speedup = baseline_time / min(safe_times)

--- a/plotting/plot_timing.py
+++ b/plotting/plot_timing.py
@@ -175,7 +175,7 @@ def plot_timing(rows, test_names=[], outdir='.'):
                 # TODO- time, use the ground-truth time.
                 data['speedup'] = data['slowest'] / data['times']
                 data['xlab'] = [to_x_label(row) for row in data['rows']]
-                data['iseql'] = [float(row['comparison_d']) == 0.0
+                data['iseql'] = [float(row['comparison']) == 0.0
                                  for row in data['rows']]
                 key = (name, host, p)
                 test_data[key] = data

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -322,7 +322,7 @@ def is_result_bad(resultfile):
         # should only have one row
         for row in parser:
             # identical to ground truth means comparison is zero
-            return float(row['comparison_d']) != 0.0
+            return float(row['comparison']) != 0.0
 
 SymbolTuple = namedtuple('SymbolTuple', 'src, symbol, demangled, fname, lineno')
 SymbolTuple.__doc__ = '''
@@ -1193,7 +1193,7 @@ def parallel_auto_bisect(arguments, prog=sys.argv[0]):
         return 1
 
     query = connection.execute(
-        'select * from tests where comparison_d != 0.0')
+        'select * from tests where comparison != 0.0')
     rows = query.fetchall()
     precision_map = {
         'f': 'float',

--- a/scripts/flitcli/flit_import.py
+++ b/scripts/flitcli/flit_import.py
@@ -183,7 +183,7 @@ def main(arguments, prog=sys.argv[0]):
             latest_run = importee_run_ids[-1]
             import_run = args.run if args.run is not None else latest_run
             cur.execute('select name,host,compiler,optl,switches,precision,'
-                        'comparison,comparison_d,file,nanosec '
+                        'comparison_hex,comparison,file,nanosec '
                         'from tests where run = ?', (import_run,))
             rows = [dict(x) for x in cur]
         else:
@@ -207,8 +207,8 @@ def main(arguments, prog=sys.argv[0]):
                 row['optl'],
                 row['switches'],
                 row['precision'],
+                row['comparison_hex'],
                 row['comparison'],
-                row['comparison_d'],
                 row['file'],
                 row['nanosec'],
                 ))
@@ -221,8 +221,8 @@ def main(arguments, prog=sys.argv[0]):
                 optl,
                 switches,
                 precision,
+                comparison_hex,
                 comparison,
-                comparison_d,
                 file,
                 nanosec)
             values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/src/flit.cpp
+++ b/src/flit.cpp
@@ -464,9 +464,9 @@ std::vector<TestResult> parseResults(std::istream &in) {
     auto nanosec = std::stol(row["nanosec"]);
     Variant value;
     std::string resultfile;
-    if (row["score"] != "NULL") {
-      // Convert score into a long double
-      value = as_float(flit::stouint128(row["score"]));
+    if (row["score_hex"] != "NULL") {
+      // Convert score_hex into a long double
+      value = as_float(flit::stouint128(row["score_hex"]));
     } else {
       // Read string from the resultfile
       if (row["resultfile"] == "NULL") {

--- a/src/flit.h
+++ b/src/flit.h
@@ -293,11 +293,11 @@ inline void outputResults (
          "optl,"
          "switches,"
          "precision,"
+         "score_hex,"
          "score,"
-         "score_d,"
          "resultfile,"
+         "comparison_hex,"
          "comparison,"
-         "comparison_d,"
          "file,"
          "nanosec"
       << std::endl;
@@ -313,13 +313,13 @@ inline void outputResults (
 
     if (result.result().type() == Variant::Type::LongDouble) {
       out
-        << as_int(result.result().longDouble()) << "," // score
-        << result.result().longDouble() << ","       // score_d
+        << as_int(result.result().longDouble()) << "," // score_hex
+        << result.result().longDouble() << ","       // score
         ;
     } else {
       out
+        << FLIT_NULL << ","                          // score_hex
         << FLIT_NULL << ","                          // score
-        << FLIT_NULL << ","                          // score_d
         ;
     }
 
@@ -331,13 +331,13 @@ inline void outputResults (
 
     if (result.is_comparison_null()) {
       out
+        << FLIT_NULL << ","                          // comparison_hex
         << FLIT_NULL << ","                          // comparison
-        << FLIT_NULL << ","                          // comparison_d
         ;
     } else {
       out
-        << as_int(result.comparison()) << ","        // comparison
-        << result.comparison() << ","                // comparison_d
+        << as_int(result.comparison()) << ","        // comparison_hex
+        << result.comparison() << ","                // comparison
         ;
     }
 

--- a/tests/flit_makefile/tst_empty_project.py
+++ b/tests/flit_makefile/tst_empty_project.py
@@ -143,7 +143,7 @@ TODO: this takes too long to run.  Can we do something faster?
 ...                                    stderr=subp.STDOUT)
 ...     print(devrun_out.decode('utf-8'), end='')
 Creating ...
-name,host,compiler,optl,switches,precision,score,score_d,resultfile,comparison,comparison_d,file,nanosec
+name,host,compiler,optl,switches,precision,score_hex,score,resultfile,comparison_hex,comparison,file,nanosec
 
 TODO: let's test that the full set of tests would get created.
 TODO: test that the custom.mk stuff gets used

--- a/tests/flit_src/tst_flit_cpp.cpp
+++ b/tests/flit_src/tst_flit_cpp.cpp
@@ -212,6 +212,7 @@ TH_REGISTER(tst_default_macro_values);
 void tst_FlitOptions_toString() {
   flit::FlitOptions opt;
   opt.help = true;
+  opt.info = false;
   opt.listTests = false;
   opt.verbose = false;
   opt.tests = {"one", "two", "three"};
@@ -228,6 +229,7 @@ void tst_FlitOptions_toString() {
   TH_EQUAL(opt.toString(),
       "Options:\n"
       "  help:           true\n"
+      "  info:           false\n"
       "  verbose:        false\n"
       "  timing:         false\n"
       "  timingLoops:    100\n"
@@ -356,7 +358,7 @@ TH_REGISTER(tst_parseArguments_long_flags);
 void tst_parseArguments_compare_test_names() {
   // tests that the parseArguments does not read the files - keep it simple
   TempFile tmpf;
-  tmpf.out << "name,precision,score,resultfile,nanosec\n"
+  tmpf.out << "name,precision,score_hex,resultfile,nanosec\n"
            << "test1,d,0x0,NULL,0\n"
            << "test2,d,0x0,NULL,0\n"
            << "test3,d,0x0,NULL,0";
@@ -593,7 +595,7 @@ namespace flit {
 }
 void tst_parseResults() {
   std::istringstream in(
-      "name,precision,score,resultfile,nanosec\n"
+      "name,precision,score_hex,resultfile,nanosec\n"
       "Mike,double,0x00000000000000000000,output.txt,149293\n"
       "Brady,long double,0x3fff8000000000000000,NULL,-1\n"
       "Julia,float,NULL,test-output.txt,498531\n"
@@ -618,22 +620,22 @@ void tst_parseResults_invalid_format() {
   TH_THROWS(flit::parseResults(in), std::invalid_argument);
 
   // empty row
-  in.str("name,precision,score,resultfile,nanosec\n"
+  in.str("name,precision,score_hex,resultfile,nanosec\n"
          "\n");
   TH_THROWS(flit::parseResults(in), std::out_of_range);
 
   // non-integer nanosec
-  in.str("name,precision,score,resultfile,nanosec\n"
+  in.str("name,precision,score_hex,resultfile,nanosec\n"
          "Mike,double,0x0,NULL,bob\n");
   TH_THROWS(flit::parseResults(in), std::invalid_argument);
 
   // non-integer score
-  in.str("name,precision,score,resultfile,nanosec\n"
+  in.str("name,precision,score_hex,resultfile,nanosec\n"
          "Mike,double,giraffe,NULL,323\n");
   TH_THROWS(flit::parseResults(in), std::invalid_argument);
 
   // doesn't end in a newline.  Make sure it doesn't throw
-  in.str("name,precision,score,resultfile,nanosec\n"
+  in.str("name,precision,score_hex,resultfile,nanosec\n"
          "Mike,double,0x0,NULL,323");
   auto actual = flit::parseResults(in);
   decltype(actual) expected;
@@ -702,7 +704,7 @@ void tst_calculateMissingComparisons_noGtFile() {
   flit::FlitOptions options;
   options.compareMode = true;
   TempFile tmpf;
-  tmpf.out << "name,precision,score,resultfile,nanosec\n"
+  tmpf.out << "name,precision,score_hex,resultfile,nanosec\n"
            << "test1,d,0x0,NULL,0\n"
            << "test2,d,0x0,NULL,0\n"
            << "test3,d,0x0,NULL,0";
@@ -716,19 +718,19 @@ TH_REGISTER(tst_calculateMissingComparisons_noGtFile);
 
 void tst_calculateMissingComparisons_withGtFile() {
   TempFile compf1;
-  compf1.out << "name,precision,score,resultfile,nanosec\n"
+  compf1.out << "name,precision,score_hex,resultfile,nanosec\n"
              << "test1,d,0x0,NULL,0\n"
              << "test2,d,0x0,NULL,0\n"
              << "test3,d,0x0,NULL,0\n";
   compf1.out.flush();
   TempFile compf2;
-  compf2.out << "name,precision,score,resultfile,nanosec\n"
+  compf2.out << "name,precision,score_hex,resultfile,nanosec\n"
              << "test2,d,0x0,NULL,0\n"
              << "test4,d,0x0,NULL,0\n"
              << "test6,d,0x0,NULL,0\n";
   compf2.out.flush();
   TempFile gtf;
-  gtf.out << "name,precision,score,resultfile,nanosec\n"
+  gtf.out << "name,precision,score_hex,resultfile,nanosec\n"
           << "test1,d,0x0,NULL,0\n"
           << "test2,d,0x0,NULL,0\n"
           << "test5,d,0x0,NULL,0\n";


### PR DESCRIPTION
Rename the columns to be more understandable.  Now, this may cause some problems with old result databases, but those can be manually updated with some SQL commands (see [here](https://stackoverflow.com/questions/805363/how-do-i-rename-a-column-in-a-sqlite-database-table#805508)).

Fixes #78 