### PR TITLE
flitHelpers: reimplement ifopen() and ofopen()

### DIFF
--- a/src/TestBase.h
+++ b/src/TestBase.h
@@ -271,7 +271,8 @@ public:
       std::string resultfile;
       if (testResult.type() == Variant::Type::String) {
         resultfile = filebase + "_" + name + "_" + typeid(T).name() + ".dat";
-        std::ofstream resultout = ofopen(resultfile);
+        std::ofstream resultout;
+        flit::ofopen(resultout, resultfile);
         resultout << testResult.string();
         testResult = Variant(); // empty the result to release memory
       }

--- a/src/flit.h
+++ b/src/flit.h
@@ -224,7 +224,8 @@ public:
   using key_type = std::pair<std::string, std::string>;
 
   void loadfile(const std::string &filename) {
-    std::ifstream resultfile = ifopen(filename);
+    std::ifstream resultfile;
+    flit::ifopen(resultfile, filename);
     auto parsed = parseResults(resultfile);
     this->extend(parsed, filename);
   }
@@ -451,7 +452,7 @@ inline int runFlitTests(int argc, char* argv[]) {
     stream_deleter.reset(new std::ofstream());
     outstream = stream_deleter.get();
     try {
-      static_cast<std::ofstream&>(*outstream) = ofopen(options.output);
+      flit::ofopen(static_cast<std::ofstream&>(*outstream), options.output);
     } catch (std::ios::failure &ex) {
       std::cerr << "Error: failed to open " << options.output << std::endl;
       return 1;
@@ -467,7 +468,7 @@ inline int runFlitTests(int argc, char* argv[]) {
     if (!options.compareGtFile.empty()) {
       std::ifstream fin;
       try {
-        fin = ifopen(options.compareGtFile);
+        flit::ifopen(fin, options.compareGtFile);
       } catch (std::ios::failure &ex) {
         std::cerr << "Error: file does not exist: " << options.compareGtFile
                   << std::endl;
@@ -542,7 +543,7 @@ inline int runFlitTests(int argc, char* argv[]) {
       {
         std::ifstream fin;
         try {
-          fin = ifopen(fname);
+          flit::ifopen(fin, fname);
         } catch (std::ios_base::failure &ex) {
           std::cerr << "Error: file does not exist: " << fname << std::endl;
           return 1;
@@ -564,7 +565,7 @@ inline int runFlitTests(int argc, char* argv[]) {
       {
         std::ofstream fout;
         try {
-          fout = ofopen(fname + options.compareSuffix);
+          flit::ofopen(fout, fname + options.compareSuffix);
         } catch (std::ios::failure &ex) {
           std::cerr << "Error: could not write to " << fname << std::endl;
           return 1;

--- a/src/flitHelpers.h
+++ b/src/flitHelpers.h
@@ -165,12 +165,14 @@ as_int(long double val) {
   return temp & (~zero >> 48);
 }
 
-/// Opens a file, but on failure, throws std::ios::failure
-/// T must be one of {fstream, ifstream, ofstream}
+/** Opens a file, but on failure, throws std::ios::failure
+ *
+ * T must be one of {fstream, ifstream, ofstream}
+ *
+ * The passed in filestream should be an empty-constructed stream
+ */
 template <typename T>
-T _openfile_check(const std::string &filename) {
-  T filestream;
-
+void _openfile_check(T& filestream, const std::string &filename) {
   // turn on exceptions on failure
   filestream.exceptions(std::ios::failbit);
 
@@ -179,21 +181,31 @@ T _openfile_check(const std::string &filename) {
 
   // turn off all exceptions (back to the default behavior)
   filestream.exceptions(std::ios::goodbit);
-
-  // This is okay because move constructor and move assignment are implemented
-  return filestream;
 }
 
-/// Opens a file for reading, but on failure, throws std::ios::failure
-inline std::ifstream ifopen(const std::string &filename) {
-  return _openfile_check<std::ifstream>(filename);
+/** Opens a file for reading, but on failure, throws std::ios::failure
+ *
+ * The passed in filestream should be an empty-constructed stream
+ *
+ * Note: This was changed to pass in the stream rather than return it because
+ * GCC 4.8 failed to compile - it failed to use the move assignment operator
+ * and move constructor, and instead tried to use the copy constructor.
+ */
+inline void ifopen(std::ifstream& in, const std::string &filename) {
+  _openfile_check<std::ifstream>(in, filename);
 }
 
-/// Opens a file for writing, but on failure, throws std::ios::failure
-inline std::ofstream ofopen(const std::string &filename) {
-  std::ofstream out = _openfile_check<std::ofstream>(filename);
+/** Opens a file for writing, but on failure, throws std::ios::failure
+ *
+ * The passed in filestream should be an empty-constructed stream
+ *
+ * Note: this was changed to pass in the stream rather than return it because
+ * GCC 4.8 failed to compile - it failed to use the move assignment operator
+ * and move constructor, and instead tried to use the copy constructor.
+ */
+inline void ofopen(std::ofstream& out, const std::string &filename) {
+  _openfile_check<std::ofstream>(out, filename);
   out.precision(1000);  // lots of digits of precision
-  return out;
 }
 
 } // end of namespace flit


### PR DESCRIPTION
The old implementation was a cleaner syntax and compiled fine
under newer compilers.  However, under GCC 4.8, it would not
compile because that compiler would try to use the copy
assignment operator, which I think is a compiler bug.  Regardless,
we changed the implementation to work around this issue so that
the tool could support GCC 4.8.