### PR TITLE
Issue173 bisect symbol by file

### DIFF
--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -91,7 +91,6 @@ import csv
 import datetime
 import glob
 import hashlib
-import itertools
 import logging
 import multiprocessing as mp
 import os

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1081,7 +1081,8 @@ def run_bisect(arguments, prog=sys.argv[0]):
         except subp.CalledProcessError:
             print()
             print('  Executable failed to run.')
-            print('Failed to search for bad symbols in -- cannot continue')
+            print('Failed to search for bad symbols in {} -- cannot continue' \
+                    .format(bad_source))
             logging.exception('Failed to search for bad symbols in %s',
                               bad_source)
         bad_symbols.extend(file_bad_symbols)

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1085,23 +1085,21 @@ def run_bisect(arguments, prog=sys.argv[0]):
             logging.exception('Failed to search for bad symbols in %s',
                               bad_source)
         bad_symbols.extend(file_bad_symbols)
-        print('  bad symbols in {}:'.format(bad_source))
-        logging.info('  bad symbols in %s:', bad_source)
-        for sym in file_bad_symbols:
-            message = '    line {sym.lineno} -- {sym.demangled}' \
-                      .format(sym=sym)
-            print(message)
-            logging.info('%s', message)
-        if len(file_bad_symbols) == 0:
-            print('    None')
-            logging.info('    None')
+        if len(file_bad_symbols) > 0:
+            print('  bad symbols in {}:'.format(bad_source))
+            logging.info('  bad symbols in %s:', bad_source)
+            for sym in file_bad_symbols:
+                message = '    line {sym.lineno} -- {sym.demangled}' \
+                          .format(sym=sym)
+                print(message)
+                logging.info('%s', message)
 
     print('All bad symbols:')
     logging.info('BAD SYMBOLS:')
     for sym in bad_symbols:
         message = '  {sym.fname}:{sym.lineno} {sym.symbol} -- {sym.demangled}' \
                   .format(sym=sym)
-        print('  ' + message)
+        print(message)
         logging.info('%s', message)
     if len(bad_symbols) == 0:
         print('    None')

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1085,8 +1085,18 @@ def run_bisect(arguments, prog=sys.argv[0]):
             logging.exception('Failed to search for bad symbols in %s',
                               bad_source)
         bad_symbols.extend(file_bad_symbols)
+        print('  bad symbols in {}:'.format(bad_source))
+        logging.info('  bad symbols in %s:', bad_source)
+        for sym in file_bad_symbols:
+            message = '    line {sym.lineno} -- {sym.demangled}' \
+                      .format(sym=sym)
+            print(message)
+            logging.info('%s', message)
+        if len(file_bad_symbols) == 0:
+            print('    None')
+            logging.info('    None')
 
-    print('  bad symbols:')
+    print('All bad symbols:')
     logging.info('BAD SYMBOLS:')
     for sym in bad_symbols:
         message = '  {sym.fname}:{sym.lineno} {sym.symbol} -- {sym.demangled}' \

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -507,10 +507,9 @@ def bisect_search(is_bad, elements):
     # Perform a sanity check.  If we have found all of the bad items, then
     # compiling with all but these bad items will cause a good build.
     # This will fail if our hypothesis class is wrong
-    if len(bad_list) > 0:
-        good_list = list(set(elements).difference(bad_list))
-        assert not is_bad(good_list, bad_list), \
-            'Assumption that bad elements are independent was wrong'
+    good_list = list(set(elements).difference(bad_list))
+    assert not is_bad(good_list, bad_list), \
+        'Assumption that bad elements are independent was wrong'
 
     return bad_list
 

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -768,10 +768,18 @@ def search_for_source_problems(args, bisect_path, replacements, sources):
     return bad_sources
 
 def search_for_symbol_problems(args, bisect_path, replacements, sources,
-                               bad_sources):
+                               bad_source):
     '''
     Performs the search over the space of symbols within bad source files for
     problems.
+
+    @param args: parsed command-line arguments
+    @param bisect_path: directory where bisect is being performed
+    @param replacements: dictionary of values to use in generating the Makefile
+    @param sources: all source files
+    @param bad_source: the one bad source file to search for bad symbols
+
+    @return a list of identified bad symbols (if any)
     '''
     def bisect_symbol_build_and_check(trouble_symbols, gt_symbols):
         '''
@@ -842,6 +850,16 @@ def search_for_symbol_problems(args, bisect_path, replacements, sources,
         message = '  {sym.fname}:{sym.lineno} {sym.symbol} -- {sym.demangled}' \
                   .format(sym=sym)
         logging.info('%s', message)
+
+    # Check to see if -fPIC destroyed any chance of finding any bad symbols
+    if not bisect_symbol_build_and_check(symbol_tuples, []):
+        message_1 = '  Warning: -fPIC compilation destroyed the optimization'
+        message_2 = '  Cannot find any trouble symbols'
+        print(message_1)
+        print(message_2)
+        logging.warning('%s', message_1)
+        logging.warning('%s', message_2)
+        return []
 
     bad_symbols = bisect_search(bisect_symbol_build_and_check, symbol_tuples)
     return bad_symbols


### PR DESCRIPTION
Fix issue #173.

Doesn't have unit tests - you decide if it needs some.  Probably could use some, but it is a bit hard to determine how much work it would be to get unit tests to test this specific functionality.  If you determine that it should have unit tests, I will make them.

Documentation is not impacted since these are implementation details, do not affect the user's experience, and the documentation on bisect does not go into such details yet.  See issue #136 

I ran this on the LaghosTest with full precision comparing `g++ -O2` with `g++ -O3 -funsafe-math-optimizations` using gcc version 5.4.0 20160609 (i.e. the version that is available in Ubuntu 16.04).

```
 817 laghos-flit-mike -- flit-tests $ flit bisect --precision double "g++ -O3 -funsafe-math-optimizations" LaghosTest
Updating ground-truth results - ground-truth.csv - done
Searching for bad source files:
  Created ./bisect-06/bisect-make-01.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-02.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-03.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-04.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-05.mk - compiling and running - good
  Created ./bisect-06/bisect-make-06.mk - compiling and running - good
  Created ./bisect-06/bisect-make-07.mk - compiling and running - good
  Created ./bisect-06/bisect-make-08.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-09.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-10.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-11.mk - compiling and running - good
  Created ./bisect-06/bisect-make-12.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-13.mk - compiling and running - good
  Created ./bisect-06/bisect-make-14.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-15.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-16.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-17.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-18.mk - compiling and running - good
  Created ./bisect-06/bisect-make-19.mk - compiling and running - good
  Created ./bisect-06/bisect-make-20.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-21.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-22.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-23.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-24.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-25.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-26.mk - compiling and running - good
  Created ./bisect-06/bisect-make-27.mk - compiling and running - good
  bad sources:
    ../raja/kernels/blas/vector_dot.cpp
    ../raja/kernels/force/rForce.cpp
    ../raja/kernels/mass/rMassMultAdd.cpp
    ../raja/kernels/quad/rQDataUpdate.cpp
Searching for bad symbols in: ../raja/kernels/blas/vector_dot.cpp
  Created ./bisect-06/bisect-make-28.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-29.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-30.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-31.mk - compiling and running - good
  bad symbols in ../raja/kernels/blas/vector_dot.cpp:
    line 58 -- vector_dot(int, double const*, double const*)
Searching for bad symbols in: ../raja/kernels/force/rForce.cpp
  Created ./bisect-06/bisect-make-32.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-33.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-34.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-35.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-36.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-37.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-38.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-39.mk - compiling and running - good
  Created ./bisect-06/bisect-make-40.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-41.mk - compiling and running - good
  Created ./bisect-06/bisect-make-42.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-43.mk - compiling and running - bad
  Created ./bisect-06/bisect-make-44.mk - compiling and running - good
  Created ./bisect-06/bisect-make-45.mk - compiling and running - good
  bad symbols in ../raja/kernels/force/rForce.cpp:
    line 487 -- rForceMult(int, int, int, int, int, int, double const*, double const*, double const*, double const*, double const*, double*)
    line 578 -- rForceMultTranspose(int, int, int, int, int, int, double const*, double const*, double const*, double const*, double const*, double*)
Searching for bad symbols in: ../raja/kernels/mass/rMassMultAdd.cpp
  Created ./bisect-06/bisect-make-46.mk - compiling and running - good
  Warning: -fPIC compilation destroyed the optimization
  Cannot find any trouble symbols
Searching for bad symbols in: ../raja/kernels/quad/rQDataUpdate.cpp
  Created ./bisect-06/bisect-make-47.mk - compiling and running - good
  Warning: -fPIC compilation destroyed the optimization
  Cannot find any trouble symbols
All bad symbols:
  /home/labuser/Laghos/flit-tests/../raja/kernels/blas/vector_dot.cpp:58 _Z10vector_dotiPKdS0_ -- vector_dot(int, double const*, double const*)
  /home/labuser/Laghos/flit-tests/../raja/kernels/force/rForce.cpp:487 _Z10rForceMultiiiiiiPKdS0_S0_S0_S0_Pd -- rForceMult(int, int, int, int, int, int, double const*, double const*, double const*, double const*, double const*, double*)
  /home/labuser/Laghos/flit-tests/../raja/kernels/force/rForce.cpp:578 _Z19rForceMultTransposeiiiiiiPKdS0_S0_S0_S0_Pd -- rForceMultTranspose(int, int, int, int, int, int, double const*, double const*, double const*, double const*, double const*, double*)
```