### PR TITLE
Issue175 bisect test one arg

### DIFF
--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -715,7 +715,7 @@ def search_for_linker_problems(args, bisect_path, replacements, sources, libs):
 
     print('Searching for bad intel static libraries:')
     logging.info('Searching for bad static libraries included by intel linker:')
-    #bas_library_msg = 'Found bad library {}'
+    #bas_library_msg = '    Found bad library {}'
     #bad_library_callback = lambda filename : \
     #                       util.printlog(bad_library_msg.format(filename))
     #bad_libs = bisect_search(bisect_libs_build_and_check, libs,
@@ -774,7 +774,7 @@ def search_for_source_problems(args, bisect_path, replacements, sources):
     logging.info('Searching for bad source files under the trouble'
                  ' compilation')
 
-    bad_source_msg = 'Found bad source file {}'
+    bad_source_msg = '    Found bad source file {}'
     bad_source_callback = lambda filename : \
                           util.printlog(bad_source_msg.format(filename))
     bad_sources = bisect_search(bisect_build_and_check, sources,
@@ -876,8 +876,8 @@ def search_for_symbol_problems(args, bisect_path, replacements, sources,
         logging.warning('%s', message_2)
         return []
 
-    bad_symbol_msg = ('Found bad symbol '
-                      '{sym.fname}:{sym.lineno} {sym.symbol} -- {sym.demangled}')
+    bad_symbol_msg = \
+        '    Found bad symbol on line {sym.lineno} -- {sym.demangled}'
     bad_symbol_callback = lambda sym : \
                           util.printlog(bad_symbol_msg.format(sym=sym))
     bad_symbols = bisect_search(bisect_symbol_build_and_check, symbol_tuples,

--- a/tests/flit_bisect/Makefile
+++ b/tests/flit_bisect/Makefile
@@ -1,0 +1,31 @@
+RUNNER        := python3
+SRC           := $(wildcard tst_*.py)
+RUN_TARGETS   := $(SRC:%.py=run_%)
+MPIRUN        := $(shell command -v mpirun 2>/dev/null)
+MPICXX        := $(shell command -v mpic++ 2>/dev/null)
+
+include ../color_out.mk
+
+.PHONY: check help clean build run_%
+ifeq ($(MPIRUN),)
+check:
+	$(call color_out,RED,Warning: mpirun is not found on your system; skipping the MPI tests)
+else ifeq ($(MPICXX),)
+check:
+	$(call color_out,RED,Warning: mpic++ is not found on your system; skipping the MPI tests)
+else
+check: $(TARGETS) $(RUN_TARGETS)
+endif
+
+help:
+	@echo "Makefile for running tests on FLiT framework"
+	@echo "  help     print this help documentation and exit"
+	@echo "  build    just compile the targets"
+	@echo "  check    run tests and print results to the console"
+	@echo "  clean    remove all generated files"
+
+build:
+clean:
+
+run_% : %.py
+	@$(RUNNER) $<

--- a/tests/flit_bisect/Makefile
+++ b/tests/flit_bisect/Makefile
@@ -1,21 +1,9 @@
 RUNNER        := python3
 SRC           := $(wildcard tst_*.py)
 RUN_TARGETS   := $(SRC:%.py=run_%)
-MPIRUN        := $(shell command -v mpirun 2>/dev/null)
-MPICXX        := $(shell command -v mpic++ 2>/dev/null)
-
-include ../color_out.mk
 
 .PHONY: check help clean build run_%
-ifeq ($(MPIRUN),)
-check:
-	$(call color_out,RED,Warning: mpirun is not found on your system; skipping the MPI tests)
-else ifeq ($(MPICXX),)
-check:
-	$(call color_out,RED,Warning: mpic++ is not found on your system; skipping the MPI tests)
-else
 check: $(TARGETS) $(RUN_TARGETS)
-endif
 
 help:
 	@echo "Makefile for running tests on FLiT framework"

--- a/tests/flit_bisect/data/tests/BisectTest.cpp
+++ b/tests/flit_bisect/data/tests/BisectTest.cpp
@@ -1,0 +1,32 @@
+#include "file1.h"
+#include "file2.h"
+#include "file3.h"
+
+#include <flit.h>
+
+#include <string>
+
+#include <cmath>
+
+template <typename T>
+class BisectTest : public flit::TestBase<T> {
+public:
+  BisectTest(std::string id) : flit::TestBase<T>(std::move(id)) {}
+  virtual size_t getInputsPerRun() override { return 0; }
+  virtual std::vector<T> getDefaultInput() override { return {}; }
+  virtual long double compare(long double ground_truth,
+                              long double test_results) const override {
+    return std::abs(test_results - ground_truth);
+  }
+
+protected:
+  virtual flit::Variant run_impl(const std::vector<T> &ti) override {
+    FLIT_UNUSED(ti);
+    return file1_all() + file2_all() + file3_all();
+  }
+
+protected:
+  using flit::TestBase<T>::id;
+};
+
+REGISTER_TYPE(BisectTest)

--- a/tests/flit_bisect/data/tests/BisectTest.cpp
+++ b/tests/flit_bisect/data/tests/BisectTest.cpp
@@ -1,3 +1,86 @@
+/* -- LICENSE BEGIN --
+ *
+ * Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * Written by
+ *   Michael Bentley (mikebentley15@gmail.com),
+ *   Geof Sawaya (fredricflinstone@gmail.com),
+ *   and Ian Briggs (ian.briggs@utah.edu)
+ * under the direction of
+ *   Ganesh Gopalakrishnan
+ *   and Dong H. Ahn.
+ *
+ * LLNL-CODE-743137
+ *
+ * All rights reserved.
+ *
+ * This file is part of FLiT. For details, see
+ *   https://pruners.github.io/flit
+ * Please also read
+ *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the disclaimer below.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the disclaimer
+ *   (as noted below) in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the LLNS/LLNL nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+ * SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Additional BSD Notice
+ *
+ * 1. This notice is required to be provided under our contract
+ *    with the U.S. Department of Energy (DOE). This work was
+ *    produced at Lawrence Livermore National Laboratory under
+ *    Contract No. DE-AC52-07NA27344 with the DOE.
+ *
+ * 2. Neither the United States Government nor Lawrence Livermore
+ *    National Security, LLC nor any of their employees, makes any
+ *    warranty, express or implied, or assumes any liability or
+ *    responsibility for the accuracy, completeness, or usefulness of
+ *    any information, apparatus, product, or process disclosed, or
+ *    represents that its use would not infringe privately-owned
+ *    rights.
+ *
+ * 3. Also, reference herein to any specific commercial products,
+ *    process, or services by trade name, trademark, manufacturer or
+ *    otherwise does not necessarily constitute or imply its
+ *    endorsement, recommendation, or favoring by the United States
+ *    Government or Lawrence Livermore National Security, LLC. The
+ *    views and opinions of authors expressed herein do not
+ *    necessarily state or reflect those of the United States
+ *    Government or Lawrence Livermore National Security, LLC, and
+ *    shall not be used for advertising or product endorsement
+ *    purposes.
+ *
+ * -- LICENSE END --
+ */
+
 #include "file1.h"
 #include "file2.h"
 #include "file3.h"

--- a/tests/flit_bisect/data/tests/file1.cpp
+++ b/tests/flit_bisect/data/tests/file1.cpp
@@ -1,0 +1,41 @@
+#include "file1.h"
+
+#include <flit.h>
+
+#include <string>
+
+int file1_func1() { return 1; }
+
+int file1_func2_PROBLEM() {
+  if (std::string(FLIT_OPTL) == "-O3") {
+    return 2 + 5;  // variability introduced = 5
+  } else {
+    return 2;
+  }
+}
+
+int file1_func3_PROBLEM() {
+  if (std::string(FLIT_OPTL) == "-O3") {
+    return 3 + 2;  // variability introduced = 2
+  } else {
+    return 3;
+  }
+}
+
+int file1_func4_PROBLEM() {
+  if (std::string(FLIT_OPTL) == "-O3") {
+    return 4 + 3;  // variability introduced = 3
+  } else {
+    return 4;
+  }
+}
+
+int file1_func5() { return 5; }
+
+int file1_all() {
+  return file1_func1()
+       + file1_func2_PROBLEM()
+       + file1_func3_PROBLEM()
+       + file1_func4_PROBLEM()
+       + file1_func5();
+}

--- a/tests/flit_bisect/data/tests/file1.cpp
+++ b/tests/flit_bisect/data/tests/file1.cpp
@@ -1,3 +1,86 @@
+/* -- LICENSE BEGIN --
+ *
+ * Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * Written by
+ *   Michael Bentley (mikebentley15@gmail.com),
+ *   Geof Sawaya (fredricflinstone@gmail.com),
+ *   and Ian Briggs (ian.briggs@utah.edu)
+ * under the direction of
+ *   Ganesh Gopalakrishnan
+ *   and Dong H. Ahn.
+ *
+ * LLNL-CODE-743137
+ *
+ * All rights reserved.
+ *
+ * This file is part of FLiT. For details, see
+ *   https://pruners.github.io/flit
+ * Please also read
+ *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the disclaimer below.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the disclaimer
+ *   (as noted below) in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the LLNS/LLNL nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+ * SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Additional BSD Notice
+ *
+ * 1. This notice is required to be provided under our contract
+ *    with the U.S. Department of Energy (DOE). This work was
+ *    produced at Lawrence Livermore National Laboratory under
+ *    Contract No. DE-AC52-07NA27344 with the DOE.
+ *
+ * 2. Neither the United States Government nor Lawrence Livermore
+ *    National Security, LLC nor any of their employees, makes any
+ *    warranty, express or implied, or assumes any liability or
+ *    responsibility for the accuracy, completeness, or usefulness of
+ *    any information, apparatus, product, or process disclosed, or
+ *    represents that its use would not infringe privately-owned
+ *    rights.
+ *
+ * 3. Also, reference herein to any specific commercial products,
+ *    process, or services by trade name, trademark, manufacturer or
+ *    otherwise does not necessarily constitute or imply its
+ *    endorsement, recommendation, or favoring by the United States
+ *    Government or Lawrence Livermore National Security, LLC. The
+ *    views and opinions of authors expressed herein do not
+ *    necessarily state or reflect those of the United States
+ *    Government or Lawrence Livermore National Security, LLC, and
+ *    shall not be used for advertising or product endorsement
+ *    purposes.
+ *
+ * -- LICENSE END --
+ */
+
 #include "file1.h"
 
 #include <flit.h>

--- a/tests/flit_bisect/data/tests/file1.h
+++ b/tests/flit_bisect/data/tests/file1.h
@@ -1,0 +1,11 @@
+#ifndef FILE1_H
+#define FILE1_H
+
+int file1_func1();
+int file1_func2_PROBLEM();  // variability = 5
+int file1_func3_PROBLEM();  // variability = 2
+int file1_func4_PROBLEM();  // variability = 3
+int file1_func5();
+int file1_all();
+
+#endif // FILE1_H

--- a/tests/flit_bisect/data/tests/file1.h
+++ b/tests/flit_bisect/data/tests/file1.h
@@ -1,3 +1,86 @@
+/* -- LICENSE BEGIN --
+ *
+ * Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * Written by
+ *   Michael Bentley (mikebentley15@gmail.com),
+ *   Geof Sawaya (fredricflinstone@gmail.com),
+ *   and Ian Briggs (ian.briggs@utah.edu)
+ * under the direction of
+ *   Ganesh Gopalakrishnan
+ *   and Dong H. Ahn.
+ *
+ * LLNL-CODE-743137
+ *
+ * All rights reserved.
+ *
+ * This file is part of FLiT. For details, see
+ *   https://pruners.github.io/flit
+ * Please also read
+ *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the disclaimer below.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the disclaimer
+ *   (as noted below) in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the LLNS/LLNL nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+ * SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Additional BSD Notice
+ *
+ * 1. This notice is required to be provided under our contract
+ *    with the U.S. Department of Energy (DOE). This work was
+ *    produced at Lawrence Livermore National Laboratory under
+ *    Contract No. DE-AC52-07NA27344 with the DOE.
+ *
+ * 2. Neither the United States Government nor Lawrence Livermore
+ *    National Security, LLC nor any of their employees, makes any
+ *    warranty, express or implied, or assumes any liability or
+ *    responsibility for the accuracy, completeness, or usefulness of
+ *    any information, apparatus, product, or process disclosed, or
+ *    represents that its use would not infringe privately-owned
+ *    rights.
+ *
+ * 3. Also, reference herein to any specific commercial products,
+ *    process, or services by trade name, trademark, manufacturer or
+ *    otherwise does not necessarily constitute or imply its
+ *    endorsement, recommendation, or favoring by the United States
+ *    Government or Lawrence Livermore National Security, LLC. The
+ *    views and opinions of authors expressed herein do not
+ *    necessarily state or reflect those of the United States
+ *    Government or Lawrence Livermore National Security, LLC, and
+ *    shall not be used for advertising or product endorsement
+ *    purposes.
+ *
+ * -- LICENSE END --
+ */
+
 #ifndef FILE1_H
 #define FILE1_H
 

--- a/tests/flit_bisect/data/tests/file2.cpp
+++ b/tests/flit_bisect/data/tests/file2.cpp
@@ -1,0 +1,26 @@
+#include "file2.h"
+
+#include <flit.h>
+
+#include <string>
+
+int file2_func1_PROBLEM() {
+  if (std::string(FLIT_OPTL) == "-O3") {
+    return 1 + 7;  // variability introduced = 7
+  } else {
+    return 1;
+  }
+}
+
+int file2_func2() { return 2; }
+int file2_func3() { return 3; }
+int file2_func4() { return 4; }
+int file2_func5() { return 5; }
+
+int file2_all() {
+  return file2_func1_PROBLEM()
+       + file2_func2()
+       + file2_func3()
+       + file2_func4()
+       + file2_func5();
+}

--- a/tests/flit_bisect/data/tests/file2.cpp
+++ b/tests/flit_bisect/data/tests/file2.cpp
@@ -1,3 +1,86 @@
+/* -- LICENSE BEGIN --
+ *
+ * Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * Written by
+ *   Michael Bentley (mikebentley15@gmail.com),
+ *   Geof Sawaya (fredricflinstone@gmail.com),
+ *   and Ian Briggs (ian.briggs@utah.edu)
+ * under the direction of
+ *   Ganesh Gopalakrishnan
+ *   and Dong H. Ahn.
+ *
+ * LLNL-CODE-743137
+ *
+ * All rights reserved.
+ *
+ * This file is part of FLiT. For details, see
+ *   https://pruners.github.io/flit
+ * Please also read
+ *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the disclaimer below.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the disclaimer
+ *   (as noted below) in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the LLNS/LLNL nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+ * SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Additional BSD Notice
+ *
+ * 1. This notice is required to be provided under our contract
+ *    with the U.S. Department of Energy (DOE). This work was
+ *    produced at Lawrence Livermore National Laboratory under
+ *    Contract No. DE-AC52-07NA27344 with the DOE.
+ *
+ * 2. Neither the United States Government nor Lawrence Livermore
+ *    National Security, LLC nor any of their employees, makes any
+ *    warranty, express or implied, or assumes any liability or
+ *    responsibility for the accuracy, completeness, or usefulness of
+ *    any information, apparatus, product, or process disclosed, or
+ *    represents that its use would not infringe privately-owned
+ *    rights.
+ *
+ * 3. Also, reference herein to any specific commercial products,
+ *    process, or services by trade name, trademark, manufacturer or
+ *    otherwise does not necessarily constitute or imply its
+ *    endorsement, recommendation, or favoring by the United States
+ *    Government or Lawrence Livermore National Security, LLC. The
+ *    views and opinions of authors expressed herein do not
+ *    necessarily state or reflect those of the United States
+ *    Government or Lawrence Livermore National Security, LLC, and
+ *    shall not be used for advertising or product endorsement
+ *    purposes.
+ *
+ * -- LICENSE END --
+ */
+
 #include "file2.h"
 
 #include <flit.h>

--- a/tests/flit_bisect/data/tests/file2.h
+++ b/tests/flit_bisect/data/tests/file2.h
@@ -1,0 +1,11 @@
+#ifndef FILE2_H
+#define FILE2_H
+
+int file2_func1_PROBLEM();  // variability = 7
+int file2_func2();
+int file2_func3();
+int file2_func4();
+int file2_func5();
+int file2_all();
+
+#endif // FILE2_H

--- a/tests/flit_bisect/data/tests/file2.h
+++ b/tests/flit_bisect/data/tests/file2.h
@@ -1,3 +1,86 @@
+/* -- LICENSE BEGIN --
+ *
+ * Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * Written by
+ *   Michael Bentley (mikebentley15@gmail.com),
+ *   Geof Sawaya (fredricflinstone@gmail.com),
+ *   and Ian Briggs (ian.briggs@utah.edu)
+ * under the direction of
+ *   Ganesh Gopalakrishnan
+ *   and Dong H. Ahn.
+ *
+ * LLNL-CODE-743137
+ *
+ * All rights reserved.
+ *
+ * This file is part of FLiT. For details, see
+ *   https://pruners.github.io/flit
+ * Please also read
+ *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the disclaimer below.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the disclaimer
+ *   (as noted below) in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the LLNS/LLNL nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+ * SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Additional BSD Notice
+ *
+ * 1. This notice is required to be provided under our contract
+ *    with the U.S. Department of Energy (DOE). This work was
+ *    produced at Lawrence Livermore National Laboratory under
+ *    Contract No. DE-AC52-07NA27344 with the DOE.
+ *
+ * 2. Neither the United States Government nor Lawrence Livermore
+ *    National Security, LLC nor any of their employees, makes any
+ *    warranty, express or implied, or assumes any liability or
+ *    responsibility for the accuracy, completeness, or usefulness of
+ *    any information, apparatus, product, or process disclosed, or
+ *    represents that its use would not infringe privately-owned
+ *    rights.
+ *
+ * 3. Also, reference herein to any specific commercial products,
+ *    process, or services by trade name, trademark, manufacturer or
+ *    otherwise does not necessarily constitute or imply its
+ *    endorsement, recommendation, or favoring by the United States
+ *    Government or Lawrence Livermore National Security, LLC. The
+ *    views and opinions of authors expressed herein do not
+ *    necessarily state or reflect those of the United States
+ *    Government or Lawrence Livermore National Security, LLC, and
+ *    shall not be used for advertising or product endorsement
+ *    purposes.
+ *
+ * -- LICENSE END --
+ */
+
 #ifndef FILE2_H
 #define FILE2_H
 

--- a/tests/flit_bisect/data/tests/file3.cpp
+++ b/tests/flit_bisect/data/tests/file3.cpp
@@ -1,3 +1,86 @@
+/* -- LICENSE BEGIN --
+ *
+ * Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * Written by
+ *   Michael Bentley (mikebentley15@gmail.com),
+ *   Geof Sawaya (fredricflinstone@gmail.com),
+ *   and Ian Briggs (ian.briggs@utah.edu)
+ * under the direction of
+ *   Ganesh Gopalakrishnan
+ *   and Dong H. Ahn.
+ *
+ * LLNL-CODE-743137
+ *
+ * All rights reserved.
+ *
+ * This file is part of FLiT. For details, see
+ *   https://pruners.github.io/flit
+ * Please also read
+ *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the disclaimer below.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the disclaimer
+ *   (as noted below) in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the LLNS/LLNL nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+ * SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Additional BSD Notice
+ *
+ * 1. This notice is required to be provided under our contract
+ *    with the U.S. Department of Energy (DOE). This work was
+ *    produced at Lawrence Livermore National Laboratory under
+ *    Contract No. DE-AC52-07NA27344 with the DOE.
+ *
+ * 2. Neither the United States Government nor Lawrence Livermore
+ *    National Security, LLC nor any of their employees, makes any
+ *    warranty, express or implied, or assumes any liability or
+ *    responsibility for the accuracy, completeness, or usefulness of
+ *    any information, apparatus, product, or process disclosed, or
+ *    represents that its use would not infringe privately-owned
+ *    rights.
+ *
+ * 3. Also, reference herein to any specific commercial products,
+ *    process, or services by trade name, trademark, manufacturer or
+ *    otherwise does not necessarily constitute or imply its
+ *    endorsement, recommendation, or favoring by the United States
+ *    Government or Lawrence Livermore National Security, LLC. The
+ *    views and opinions of authors expressed herein do not
+ *    necessarily state or reflect those of the United States
+ *    Government or Lawrence Livermore National Security, LLC, and
+ *    shall not be used for advertising or product endorsement
+ *    purposes.
+ *
+ * -- LICENSE END --
+ */
+
 #include "file1.h"
 
 #include <flit.h>

--- a/tests/flit_bisect/data/tests/file3.cpp
+++ b/tests/flit_bisect/data/tests/file3.cpp
@@ -1,0 +1,34 @@
+#include "file1.h"
+
+#include <flit.h>
+
+#include <string>
+
+int file3_func1() { return 1; }
+
+int file3_func2_PROBLEM() {
+  if (std::string(FLIT_OPTL) == "-O3") {
+    return 2 + 1;  // variability introduced = 1
+  } else {
+    return 2;
+  }
+}
+
+int file3_func3() { return 3; }
+int file3_func4() { return 4; }
+
+int file3_func5_PROBLEM() {
+  if (std::string(FLIT_OPTL) == "-O3") {
+    return 5 + 3;  // variability introduced = 3
+  } else {
+    return 5;
+  }
+}
+
+int file3_all() {
+  return file3_func1()
+       + file3_func2_PROBLEM()
+       + file3_func3()
+       + file3_func4()
+       + file3_func5_PROBLEM();
+}

--- a/tests/flit_bisect/data/tests/file3.h
+++ b/tests/flit_bisect/data/tests/file3.h
@@ -1,3 +1,86 @@
+/* -- LICENSE BEGIN --
+ *
+ * Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * Written by
+ *   Michael Bentley (mikebentley15@gmail.com),
+ *   Geof Sawaya (fredricflinstone@gmail.com),
+ *   and Ian Briggs (ian.briggs@utah.edu)
+ * under the direction of
+ *   Ganesh Gopalakrishnan
+ *   and Dong H. Ahn.
+ *
+ * LLNL-CODE-743137
+ *
+ * All rights reserved.
+ *
+ * This file is part of FLiT. For details, see
+ *   https://pruners.github.io/flit
+ * Please also read
+ *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the disclaimer below.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the disclaimer
+ *   (as noted below) in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the LLNS/LLNL nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+ * SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Additional BSD Notice
+ *
+ * 1. This notice is required to be provided under our contract
+ *    with the U.S. Department of Energy (DOE). This work was
+ *    produced at Lawrence Livermore National Laboratory under
+ *    Contract No. DE-AC52-07NA27344 with the DOE.
+ *
+ * 2. Neither the United States Government nor Lawrence Livermore
+ *    National Security, LLC nor any of their employees, makes any
+ *    warranty, express or implied, or assumes any liability or
+ *    responsibility for the accuracy, completeness, or usefulness of
+ *    any information, apparatus, product, or process disclosed, or
+ *    represents that its use would not infringe privately-owned
+ *    rights.
+ *
+ * 3. Also, reference herein to any specific commercial products,
+ *    process, or services by trade name, trademark, manufacturer or
+ *    otherwise does not necessarily constitute or imply its
+ *    endorsement, recommendation, or favoring by the United States
+ *    Government or Lawrence Livermore National Security, LLC. The
+ *    views and opinions of authors expressed herein do not
+ *    necessarily state or reflect those of the United States
+ *    Government or Lawrence Livermore National Security, LLC, and
+ *    shall not be used for advertising or product endorsement
+ *    purposes.
+ *
+ * -- LICENSE END --
+ */
+
 #ifndef FILE3_H
 #define FILE3_H
 

--- a/tests/flit_bisect/data/tests/file3.h
+++ b/tests/flit_bisect/data/tests/file3.h
@@ -1,0 +1,11 @@
+#ifndef FILE3_H
+#define FILE3_H
+
+int file3_func1();
+int file3_func2_PROBLEM(); // variability = 1
+int file3_func3();
+int file3_func4();
+int file3_func5_PROBLEM(); // variability = 3
+int file3_all();
+
+#endif // FILE3_H

--- a/tests/flit_bisect/tst_bisect.py
+++ b/tests/flit_bisect/tst_bisect.py
@@ -136,35 +136,35 @@ Searching for bad symbols in: tests/file1.cpp
   Created /.../bisect-01/bisect-make-14.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-15.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-16.mk - compiling and running - bad
-    Found bad symbol on line 9 -- file1_func2_PROBLEM()
+    Found bad symbol on line 92 -- file1_func2_PROBLEM()
   Created /.../bisect-01/bisect-make-17.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-18.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-19.mk - compiling and running - bad
-    Found bad symbol on line 17 -- file1_func3_PROBLEM()
+    Found bad symbol on line 100 -- file1_func3_PROBLEM()
   Created /.../bisect-01/bisect-make-20.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-21.mk - compiling and running - bad
-    Found bad symbol on line 25 -- file1_func4_PROBLEM()
+    Found bad symbol on line 108 -- file1_func4_PROBLEM()
   Created /.../bisect-01/bisect-make-22.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-23.mk - compiling and running - good
   bad symbols in tests/file1.cpp:
-    line 9 -- file1_func2_PROBLEM()
-    line 17 -- file1_func3_PROBLEM()
-    line 25 -- file1_func4_PROBLEM()
+    line 92 -- file1_func2_PROBLEM()
+    line 100 -- file1_func3_PROBLEM()
+    line 108 -- file1_func4_PROBLEM()
 Searching for bad symbols in: tests/file3.cpp
   Created /.../bisect-01/bisect-make-24.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-25.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-26.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-27.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-28.mk - compiling and running - bad
-    Found bad symbol on line 9 -- file3_func2_PROBLEM()
+    Found bad symbol on line 92 -- file3_func2_PROBLEM()
   Created /.../bisect-01/bisect-make-29.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-30.mk - compiling and running - bad
-    Found bad symbol on line 20 -- file3_func5_PROBLEM()
+    Found bad symbol on line 103 -- file3_func5_PROBLEM()
   Created /.../bisect-01/bisect-make-31.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-32.mk - compiling and running - good
   bad symbols in tests/file3.cpp:
-    line 9 -- file3_func2_PROBLEM()
-    line 20 -- file3_func5_PROBLEM()
+    line 92 -- file3_func2_PROBLEM()
+    line 103 -- file3_func5_PROBLEM()
 Searching for bad symbols in: tests/file2.cpp
   Created /.../bisect-01/bisect-make-33.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-34.mk - compiling and running - bad
@@ -172,18 +172,18 @@ Searching for bad symbols in: tests/file2.cpp
   Created /.../bisect-01/bisect-make-36.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-37.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-38.mk - compiling and running - bad
-    Found bad symbol on line 8 -- file2_func1_PROBLEM()
+    Found bad symbol on line 91 -- file2_func1_PROBLEM()
   Created /.../bisect-01/bisect-make-39.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-40.mk - compiling and running - good
   bad symbols in tests/file2.cpp:
-    line 8 -- file2_func1_PROBLEM()
+    line 91 -- file2_func1_PROBLEM()
 All bad symbols:
-  /.../tests/file1.cpp:9 ... -- file1_func2_PROBLEM()
-  /.../tests/file1.cpp:17 ... -- file1_func3_PROBLEM()
-  /.../tests/file1.cpp:25 ... -- file1_func4_PROBLEM()
-  /.../tests/file3.cpp:9 ... -- file3_func2_PROBLEM()
-  /.../tests/file3.cpp:20 ... -- file3_func5_PROBLEM()
-  /.../tests/file2.cpp:8 ... -- file2_func1_PROBLEM()
+  /.../tests/file1.cpp:92 ... -- file1_func2_PROBLEM()
+  /.../tests/file1.cpp:100 ... -- file1_func3_PROBLEM()
+  /.../tests/file1.cpp:108 ... -- file1_func4_PROBLEM()
+  /.../tests/file3.cpp:92 ... -- file3_func2_PROBLEM()
+  /.../tests/file3.cpp:103 ... -- file3_func5_PROBLEM()
+  /.../tests/file2.cpp:91 ... -- file2_func1_PROBLEM()
 
 TODO: test the log_contents variable
 '''

--- a/tests/flit_bisect/tst_bisect.py
+++ b/tests/flit_bisect/tst_bisect.py
@@ -116,14 +116,14 @@ Searching for bad source files:
   Created /.../bisect-01/bisect-make-02.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-03.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-04.mk - compiling and running - bad
-Found bad source file tests/file1.cpp
+    Found bad source file tests/file1.cpp
   Created /.../bisect-01/bisect-make-05.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-06.mk - compiling and running - bad
-Found bad source file tests/file3.cpp
+    Found bad source file tests/file3.cpp
   Created /.../bisect-01/bisect-make-07.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-08.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-09.mk - compiling and running - bad
-Found bad source file tests/file2.cpp
+    Found bad source file tests/file2.cpp
   Created /.../bisect-01/bisect-make-10.mk - compiling and running - good
   bad sources:
     tests/file1.cpp
@@ -136,14 +136,14 @@ Searching for bad symbols in: tests/file1.cpp
   Created /.../bisect-01/bisect-make-14.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-15.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-16.mk - compiling and running - bad
-Found bad symbol /.../tests/file1.cpp:9 ... -- file1_func2_PROBLEM()
+    Found bad symbol on line 9 -- file1_func2_PROBLEM()
   Created /.../bisect-01/bisect-make-17.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-18.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-19.mk - compiling and running - bad
-Found bad symbol /.../tests/file1.cpp:17 ... -- file1_func3_PROBLEM()
+    Found bad symbol on line 17 -- file1_func3_PROBLEM()
   Created /.../bisect-01/bisect-make-20.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-21.mk - compiling and running - bad
-Found bad symbol /.../tests/file1.cpp:25 ... -- file1_func4_PROBLEM()
+    Found bad symbol on line 25 -- file1_func4_PROBLEM()
   Created /.../bisect-01/bisect-make-22.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-23.mk - compiling and running - good
   bad symbols in tests/file1.cpp:
@@ -156,10 +156,10 @@ Searching for bad symbols in: tests/file3.cpp
   Created /.../bisect-01/bisect-make-26.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-27.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-28.mk - compiling and running - bad
-Found bad symbol /.../tests/file3.cpp:9 ... -- file3_func2_PROBLEM()
+    Found bad symbol on line 9 -- file3_func2_PROBLEM()
   Created /.../bisect-01/bisect-make-29.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-30.mk - compiling and running - bad
-Found bad symbol /.../tests/file3.cpp:20 ... -- file3_func5_PROBLEM()
+    Found bad symbol on line 20 -- file3_func5_PROBLEM()
   Created /.../bisect-01/bisect-make-31.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-32.mk - compiling and running - good
   bad symbols in tests/file3.cpp:
@@ -172,7 +172,7 @@ Searching for bad symbols in: tests/file2.cpp
   Created /.../bisect-01/bisect-make-36.mk - compiling and running - bad
   Created /.../bisect-01/bisect-make-37.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-38.mk - compiling and running - bad
-Found bad symbol /.../tests/file2.cpp:8 ... -- file2_func1_PROBLEM()
+    Found bad symbol on line 8 -- file2_func1_PROBLEM()
   Created /.../bisect-01/bisect-make-39.mk - compiling and running - good
   Created /.../bisect-01/bisect-make-40.mk - compiling and running - good
   bad symbols in tests/file2.cpp:

--- a/tests/flit_bisect/tst_bisect.py
+++ b/tests/flit_bisect/tst_bisect.py
@@ -1,0 +1,201 @@
+# -- LICENSE BEGIN --
+#
+# Copyright (c) 2015-2018, Lawrence Livermore National Security, LLC.
+#
+# Produced at the Lawrence Livermore National Laboratory
+#
+# Written by
+#   Michael Bentley (mikebentley15@gmail.com),
+#   Geof Sawaya (fredricflinstone@gmail.com),
+#   and Ian Briggs (ian.briggs@utah.edu)
+# under the direction of
+#   Ganesh Gopalakrishnan
+#   and Dong H. Ahn.
+#
+# LLNL-CODE-743137
+#
+# All rights reserved.
+#
+# This file is part of FLiT. For details, see
+#   https://pruners.github.io/flit
+# Please also read
+#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
+# conditions are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the disclaimer below.
+#
+# - Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the disclaimer
+#   (as noted below) in the documentation and/or other materials
+#   provided with the distribution.
+#
+# - Neither the name of the LLNS/LLNL nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL
+# SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Additional BSD Notice
+#
+# 1. This notice is required to be provided under our contract
+#    with the U.S. Department of Energy (DOE). This work was
+#    produced at Lawrence Livermore National Laboratory under
+#    Contract No. DE-AC52-07NA27344 with the DOE.
+#
+# 2. Neither the United States Government nor Lawrence Livermore
+#    National Security, LLC nor any of their employees, makes any
+#    warranty, express or implied, or assumes any liability or
+#    responsibility for the accuracy, completeness, or usefulness of
+#    any information, apparatus, product, or process disclosed, or
+#    represents that its use would not infringe privately-owned
+#    rights.
+#
+# 3. Also, reference herein to any specific commercial products,
+#    process, or services by trade name, trademark, manufacturer or
+#    otherwise does not necessarily constitute or imply its
+#    endorsement, recommendation, or favoring by the United States
+#    Government or Lawrence Livermore National Security, LLC. The
+#    views and opinions of authors expressed herein do not
+#    necessarily state or reflect those of the United States
+#    Government or Lawrence Livermore National Security, LLC, and
+#    shall not be used for advertising or product endorsement
+#    purposes.
+#
+# -- LICENSE END --
+
+'''
+Tests FLiT's capabilities to run bisect and identify the problem files and
+functions
+
+The tests are below using doctest
+
+Let's now make a temporary directory and test that we can successfully compile
+and run FLiT bisect
+
+>>> import glob
+>>> import os
+>>> import shutil
+>>> import subprocess as subp
+
+>>> with th.tempdir() as temp_dir:
+...     _ = th.flit.main(['init', '-C', temp_dir]) # doctest:+ELLIPSIS
+...     print()
+...     shutil.rmtree(os.path.join(temp_dir, 'tests'))
+...     _ = shutil.copytree(os.path.join('data', 'tests'),
+...                         os.path.join(temp_dir, 'tests'))
+...     _ = th.flit.main(['bisect', '-C', temp_dir, '--precision', 'double',
+...                       'g++ -O3', 'BisectTest']) # doctest:+ELLIPSIS
+...     with open(os.path.join(temp_dir, 'bisect-01', 'bisect.log')) as fin:
+...         log_contents = fin.read()
+Creating /.../flit-config.toml
+Creating /.../custom.mk
+Creating /.../main.cpp
+Creating /.../tests/Empty.cpp
+Creating /.../Makefile
+<BLANKLINE>
+Updating ground-truth results - ground-truth.csv - done
+Searching for bad source files:
+  Created /.../bisect-01/bisect-make-01.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-02.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-03.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-04.mk - compiling and running - bad
+Found bad source file tests/file1.cpp
+  Created /.../bisect-01/bisect-make-05.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-06.mk - compiling and running - bad
+Found bad source file tests/file3.cpp
+  Created /.../bisect-01/bisect-make-07.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-08.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-09.mk - compiling and running - bad
+Found bad source file tests/file2.cpp
+  Created /.../bisect-01/bisect-make-10.mk - compiling and running - good
+  bad sources:
+    tests/file1.cpp
+    tests/file3.cpp
+    tests/file2.cpp
+Searching for bad symbols in: tests/file1.cpp
+  Created /.../bisect-01/bisect-make-11.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-12.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-13.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-14.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-15.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-16.mk - compiling and running - bad
+Found bad symbol /.../tests/file1.cpp:9 ... -- file1_func2_PROBLEM()
+  Created /.../bisect-01/bisect-make-17.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-18.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-19.mk - compiling and running - bad
+Found bad symbol /.../tests/file1.cpp:17 ... -- file1_func3_PROBLEM()
+  Created /.../bisect-01/bisect-make-20.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-21.mk - compiling and running - bad
+Found bad symbol /.../tests/file1.cpp:25 ... -- file1_func4_PROBLEM()
+  Created /.../bisect-01/bisect-make-22.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-23.mk - compiling and running - good
+  bad symbols in tests/file1.cpp:
+    line 9 -- file1_func2_PROBLEM()
+    line 17 -- file1_func3_PROBLEM()
+    line 25 -- file1_func4_PROBLEM()
+Searching for bad symbols in: tests/file3.cpp
+  Created /.../bisect-01/bisect-make-24.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-25.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-26.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-27.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-28.mk - compiling and running - bad
+Found bad symbol /.../tests/file3.cpp:9 ... -- file3_func2_PROBLEM()
+  Created /.../bisect-01/bisect-make-29.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-30.mk - compiling and running - bad
+Found bad symbol /.../tests/file3.cpp:20 ... -- file3_func5_PROBLEM()
+  Created /.../bisect-01/bisect-make-31.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-32.mk - compiling and running - good
+  bad symbols in tests/file3.cpp:
+    line 9 -- file3_func2_PROBLEM()
+    line 20 -- file3_func5_PROBLEM()
+Searching for bad symbols in: tests/file2.cpp
+  Created /.../bisect-01/bisect-make-33.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-34.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-35.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-36.mk - compiling and running - bad
+  Created /.../bisect-01/bisect-make-37.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-38.mk - compiling and running - bad
+Found bad symbol /.../tests/file2.cpp:8 ... -- file2_func1_PROBLEM()
+  Created /.../bisect-01/bisect-make-39.mk - compiling and running - good
+  Created /.../bisect-01/bisect-make-40.mk - compiling and running - good
+  bad symbols in tests/file2.cpp:
+    line 8 -- file2_func1_PROBLEM()
+All bad symbols:
+  /.../tests/file1.cpp:9 ... -- file1_func2_PROBLEM()
+  /.../tests/file1.cpp:17 ... -- file1_func3_PROBLEM()
+  /.../tests/file1.cpp:25 ... -- file1_func4_PROBLEM()
+  /.../tests/file3.cpp:9 ... -- file3_func2_PROBLEM()
+  /.../tests/file3.cpp:20 ... -- file3_func5_PROBLEM()
+  /.../tests/file2.cpp:8 ... -- file2_func1_PROBLEM()
+
+TODO: test the log_contents variable
+'''
+
+# Test setup before the docstring is run.
+import sys
+before_path = sys.path[:]
+sys.path.append('..')
+import test_harness as th
+sys.path = before_path
+
+if __name__ == '__main__':
+    from doctest import testmod
+    failures, tests = testmod()
+    sys.exit(failures)


### PR DESCRIPTION
Fix #175 so that the `is_bad()` function passed to `bisect_search()` only takes the list of variables to test, and not the complement.

I also added a unit test for bisect that actually tests to see if bisect can identify blamed files and symbols.  This partially addresses #137.  It is fairly comprehensive for the basic functionality of bisect.  It does not address all of the features of bisect.  It is also a bit too hard-coded to the current behavior and is not very generic and is able to break from small changes to bisect implementation.

Documentation: this change does not change anything that is specified in the documentation, so no changes here necessary

Testing: test is added and all tests pass