### PR TITLE
Issue182 travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,10 +81,13 @@
 # -- LICENSE END --
 
 language: cpp
-  addons:
-    apt:
-      packages:
-        - python3-toml
+addons:
+  apt:
+    packages:
+    - python3
+    - python3-toml
+    - openmpi-bin
+    - libopenmpi-dev
 
 script: make -j 4 && make check
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,11 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - python3
-    - python3-toml
+    - python3-pip
     - openmpi-bin
     - libopenmpi-dev
+
+before_install: pip3 install --user toml
 
 script: make -j 4 && make check
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@
 # -- LICENSE END --
 
 language: cpp
+dist: xenial
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,39 +80,18 @@
 #
 # -- LICENSE END --
 
-sudo: required
 language: cpp
-dist: trusty
-# addons:
-#   apt:
-#     packages:
-#     - gcc-5
-#     - g++-5
+  addons:
+    apt:
+      packages:
+        - python3-toml
 
-env:
-  global:
-    - LLVM_VERSION=3.9.0
-    - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
-    - export PATH=$HOME/usr/bin:$PATH
-    - export LD_LIBRARY_PATH=$HOME/usr/lib:$LD_LIBRARY_PATH
+script: make -j 4 && make check
 
-install:
-  #starts in $HOME/build/PRUNERS/FLiT
-  - cd $HOME/build
-  # Install LLVM/Clang 3.9
-  - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
-  - mkdir $HOME/usr
-  - tar xf $LLVM_ARCHIVE_PATH -C $HOME/usr --strip-components 1
-  
-# script:
-  - export CLANG_ONLY=True
-  - cd $HOME/build/PRUNERS/FLiT/src
-  - make -j 4
-
-notifications:
-  email: false
-  slack:
-    rooms:
-      - pruners:aXHVdiVFtqtMfzNW4IutZNDW
-    on_success: always
-    on_failure: always
+#notifications:
+#  email: false
+#  slack:
+#    rooms:
+#      - pruners:aXHVdiVFtqtMfzNW4IutZNDW
+#    on_success: always
+#    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,11 @@
 # -- LICENSE END --
 
 language: cpp
-dist: xenial
+os: linux
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
     - python3
     - python3-toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,13 +84,11 @@ language: cpp
 os: linux
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - python3
-    - python3-pip
-    - openmpi-bin
-    - libopenmpi-dev
+      - python3
+      - python3-pip
+      - openmpi-bin
+      - libopenmpi-dev
 
 before_install: pip3 install --user toml
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX         ?= /usr
 
-#CC             := clang++
-CC             := g++
+#CXX            ?= clang++
+CXX            ?= g++
 FFLAGS         ?=
 LIBDIR         := lib
 SRCDIR         := src
@@ -68,10 +68,10 @@ help:
 
 $(TARGET): $(OBJ)
 	mkdir -p lib
-	$(CC) $(CPPFLAGS) -o $@ $^ $(LINKFLAGS)
+	$(CXX) $(CPPFLAGS) -o $@ $^ $(LINKFLAGS)
 
 $(SRCDIR)/%.o: $(SRCDIR)/%.cpp Makefile
-	$(CC) $(CPPFLAGS) $(DEPFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(DEPFLAGS) -c $< -o $@
 
 .PRECIOUS: src/%.d
 -include $(SOURCE:%.cpp=%.d)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+| branch  | status  |
+|---------|---------|
+| master  | [![Build Status](https://travis-ci.org/PRUNERS/FLiT.svg?branch=master)](https://travis-ci.org/PRUNERS/FLiT) |
+| devel   | [![Build Status](https://travis-ci.org/PRUNERS/FLiT.svg?branch=devel)](https://travis-ci.org/PRUNERS/FLiT) |
+
 # FLiT
 
 [![FLiT Bird](/images/flit-small.png)](https://github.com/PRUNERS/FLiT "FLiT")

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -178,16 +178,6 @@ IS_GCC_4_OR_5    = $(shell expr $(call IS_GCC,$1) \& \
 DEV_LDFLAGS      =
 GT_LDFLAGS       =
 
-# if the dev compiler is not an old version of GCC
-ifeq ($(call IS_GCC_4_OR_5,$(DEV_CC)),0)
-  DEV_LDFLAGS   += -no-pie
-endif
-
-# if the gt compiler is not an old version of GCC
-ifeq ($(call IS_GCC_4_OR_5,$(GT_CC)),0)
-  GT_LDFLAGS    += -no-pie
-endif
-
 DEPFLAGS        += -MMD -MF $(patsubst %.o,%.d,$@)
 
 TESTS            = $(wildcard tests/*.cpp)
@@ -428,6 +418,16 @@ $(OBJ_DIR)/%_$(R_ID).o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 
 # Otherwise, we're not in a recursion.
 else # ifndef R_IS_RECURSED
+
+# if the dev compiler is not an old version of GCC
+ifeq ($(call IS_GCC_4_OR_5,$(DEV_CC)),0)
+  DEV_LDFLAGS   += -no-pie
+endif
+
+# if the gt compiler is not an old version of GCC
+ifeq ($(call IS_GCC_4_OR_5,$(GT_CC)),0)
+  GT_LDFLAGS    += -no-pie
+endif
 
 $(OBJ_DIR):
 	mkdir -p $(OBJ_DIR)

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -137,7 +137,9 @@ DEV_CFLAGS      += -Wuninitialized
 DEV_CFLAGS      += -Wno-shift-count-overflow
 
 # This flag specifies NOT to link as a position-independent executable
-LD_REQUIRED     += -no-pie
+# Note: this flag does not exist in GCC 4 or GCC 5 so it will fail to compile
+#       we need extra logic to check for this and conditionally add this flag
+#LD_REQUIRED     += -no-pie
 LD_REQUIRED     += -lm
 LD_REQUIRED     += -lstdc++
 ifeq ($(UNAME_S),Darwin) # If we are on a Mac OSX system
@@ -147,7 +149,44 @@ else
   LD_REQUIRED   += -Wl,-rpath=$(realpath $(FLIT_LIB_DIR))
 endif
 
-DEV_LDFLAGS     +=
+# Helper functions to determine if the compiler is a particular version of GCC
+
+# Returns the compiler name as output by the --version flag
+# @param 1: executable name or path to compiler
+GET_COMPILER     = $(shell $1 --version | head -n 1 | awk '{{ print $$1 }}')
+
+# Returns 1 if the given compiler is GCC, else 0
+# @param 1: executable name or path to compiler
+IS_GCC           = $(shell expr $(call GET_COMPILER,$(1)) = gcc \| \
+                                $(call GET_COMPILER,$1) = g++)
+
+# Returns the version of the compiler as returned by -dumpversion
+# @param 1: executable name or path to compiler
+GET_COMPILER_VER = $(shell $1 -dumpversion)
+
+# Returns 1 if the major version matches else 0
+# @param 1: executable name or path to compiler
+# @param 2: major version number as an integer
+IS_MAJOR_VER     = $(shell expr substr $(call GET_COMPILER_VER,$1) 1 1 = $2)
+
+# Returns 1 if the compiler is GCC version 4 or version 5
+# @param 1: executable name or path to compiler
+IS_GCC_4_OR_5    = $(shell expr $(call IS_GCC,$1) \& \
+                             \( $(call IS_MAJOR_VER,$1,4) \| \
+                                $(call IS_MAJOR_VER,$1,5) \))
+
+DEV_LDFLAGS      =
+GT_LDFLAGS       =
+
+# if the dev compiler is not an old version of GCC
+ifeq ($(call IS_GCC_4_OR_5,$(DEV_CC)),0)
+  DEV_LDFLAGS   += -no-pie
+endif
+
+# if the gt compiler is not an old version of GCC
+ifeq ($(call IS_GCC_4_OR_5,$(GT_CC)),0)
+  GT_LDFLAGS    += -no-pie
+endif
 
 DEPFLAGS        += -MMD -MF $(patsubst %.o,%.d,$@)
 
@@ -365,6 +404,11 @@ R_DEP           := $(R_OBJ:%.o=%.d)
 .PHONY: rec
 rec: $(R_TARGET)
 
+# if the current compiler is not GCC 4 or 5, then enable -no-pie
+ifeq ($(call IS_GCC_4_OR_5,$($(R_CUR_COMPILER))),0)
+  LD_REQUIRED += -no-pie
+endif
+
 $(R_TARGET): $(R_OBJ)
 	$($(R_CUR_COMPILER)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
 	  $($(R_CUR_COMPILER)_REQUIRED) $(CC_REQUIRED) \
@@ -530,7 +574,7 @@ $(GT_OUT): $(GT_TARGET)
 	$(RUNWRAP) ./$(GT_TARGET) --output $(GT_OUT) --no-timing
 
 $(GT_TARGET): $(GT_OBJ) Makefile custom.mk
-	$(GT_CC) $(CC_REQUIRED) -o $@ $(GT_OBJ) $(LD_REQUIRED)
+	$(GT_CC) $(CC_REQUIRED) -o $@ $(GT_OBJ) $(LD_REQUIRED) $(GT_LDFLAGS)
 
 $(OBJ_DIR)/%_gt.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 	$(GT_CC) -g $(GT_OPTL) $(GT_SWITCHES) $(CC_REQUIRED) $(DEPFLAGS) -c $< -o $@ \

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -124,6 +124,13 @@ SPLIT_SRC        :=
 {EXTRA_CC_FLAGS}
 {EXTRA_LD_FLAGS}
 
+TROUBLE_LDFLAGS   =
+
+# if the trouble compiler is not GCC 4 or 5, then add -no-pie
+ifeq ($(call IS_GCC_4_OR_5,$(TROUBLE_CC)),0)
+  TROUBLE_LDFLAGS += -no-pie
+endif
+
 BUILD_GT_LOCAL   := {build_gt_local}
 
 TROUBLE_TARGET_OBJ := $(addprefix \
@@ -204,10 +211,10 @@ $(TROUBLE_TARGET_OUT): $(TROUBLE_TARGET) | $(BISECT_DIR)
 	$(RUNWRAP) ./$< --precision "$(PRECISION)" --output $@ $(TEST_CASE) --no-timing
 
 $(BISECT_TARGET): $(BISECT_OBJ) $(SPLIT_OBJ) Makefile custom.mk | $(BISECT_DIR)
-	$(GT_CC) $(CC_REQUIRED) -o $@ $(BISECT_OBJ) $(SPLIT_OBJ) $(LD_REQUIRED)
+	$(GT_CC) $(CC_REQUIRED) -o $@ $(BISECT_OBJ) $(SPLIT_OBJ) $(LD_REQUIRED) $(GT_LDFLAGS)
 
 $(TROUBLE_TARGET): $(TROUBLE_TARGET_OBJ) Makefile custom.mk | $(BISECT_DIR)
-	$(TROUBLE_CC) $(CC_REQUIRED) -o $@ $(TROUBLE_TARGET_OBJ) $(LD_REQUIRED)
+	$(TROUBLE_CC) $(CC_REQUIRED) -o $@ $(TROUBLE_TARGET_OBJ) $(LD_REQUIRED) $(TROUBLE_LDFLAGS)
 
 .PHONY: trouble trouble-out
 trouble: $(TROUBLE_TARGET)

--- a/scripts/flitcli/flit.py
+++ b/scripts/flitcli/flit.py
@@ -160,7 +160,26 @@ def generate_help_documentation(subcom_map):
 
     return (parser.format_help(), help_subparser.format_help())
 
-def main(arguments):
+def main(arguments, outstream=sys.stdout):
+    '''
+    Main logic here.
+
+    For ease of use when within python, the stdout can be captured using the
+    optional outstream parameter.  You can use this to capture the stdout that
+    would go to the console and put it into a StringStream or maybe a file.
+    '''
+    if outstream == sys.stdout:
+        return _main_impl(arguments)
+    else:
+        try:
+            oldout = sys.stdout
+            sys.stdout = outstream
+            _main_impl(arguments)
+        finally:
+            sys.stdout = oldout
+
+def _main_impl(arguments):
+    'Implementation of main'
     script_dir = os.path.dirname(os.path.realpath(__file__))
     sys.path.insert(0, script_dir)
     import flitconfig as conf

--- a/scripts/flitcli/flit.py
+++ b/scripts/flitcli/flit.py
@@ -160,7 +160,7 @@ def generate_help_documentation(subcom_map):
 
     return (parser.format_help(), help_subparser.format_help())
 
-def main(arguments, outstream=sys.stdout):
+def main(arguments, outstream=None):
     '''
     Main logic here.
 
@@ -168,7 +168,7 @@ def main(arguments, outstream=sys.stdout):
     optional outstream parameter.  You can use this to capture the stdout that
     would go to the console and put it into a StringStream or maybe a file.
     '''
-    if outstream == sys.stdout:
+    if outstream is None:
         return _main_impl(arguments)
     else:
         try:

--- a/tests/flit_install/tst_uninstall_runthrough.py
+++ b/tests/flit_install/tst_uninstall_runthrough.py
@@ -121,10 +121,12 @@ PREFIX path
 ...                         stdout=subp.DEVNULL, stderr=subp.DEVNULL)
 ...     prevdir = os.path.realpath(os.curdir)
 ...     os.chdir(temp_dir)
-...     all_files = glob.glob('**', recursive=True)
+...     all_files = [os.path.join(base, name)
+...                  for base, folders, filenames in os.walk('.')
+...                  for name in folders + filenames]
 ...     os.chdir(prevdir)
 >>> sorted(all_files)
-['lib', 'lib/otherlib.so']
+['./lib', './lib/otherlib.so']
 '''
 
 # Test setup before the docstring is run.

--- a/tests/flit_mpi/tst_run_mpi.py
+++ b/tests/flit_mpi/tst_run_mpi.py
@@ -137,15 +137,15 @@ Creating /.../Makefile
 
 Make sure the info statement about MPI being enabled is done at each make call
 
->>> compile_str[1]
-'MPI is enabled'
->>> run_str[1]
-'MPI is enabled'
+>>> 'MPI is enabled' in compile_str
+True
+>>> 'MPI is enabled' in run_str
+True
 
 Make sure the correct arguments are passed to mpirun
 
->>> run_str[2]
-'mpirun -n 2 ./gtrun --output ground-truth.csv --no-timing'
+>>> 'mpirun -n 2 ./gtrun --output ground-truth.csv --no-timing' in run_str
+True
 
 Make sure the console messages are there, but they can be out of order
 

--- a/tests/flit_src/tst_flit_cpp.cpp
+++ b/tests/flit_src/tst_flit_cpp.cpp
@@ -90,6 +90,7 @@
 
 #include <algorithm>
 #include <array>
+#include <ios>
 #include <memory>
 #include <sstream>
 #include <vector>
@@ -577,7 +578,7 @@ TH_REGISTER(tst_readFile_exists);
 
 void tst_readFile_doesnt_exist() {
   TH_THROWS(flit::readFile("/this/file/should/not/exist"),
-            std::system_error);
+            std::ios_base::failure);
 }
 TH_REGISTER(tst_readFile_doesnt_exist);
 


### PR DESCRIPTION
Address issue #182.   This is to get continuous integration working for FLiT.  For some time now, we have had unit tests within FLiT.  Now it is time to make those unit tests run for every push and every pull request.  This pull request makes that all possible.

This was tricky since Travis CI by default runs on Ubuntu 14.04 which sports GCC 4.8.4.  That broke many things which needed fixing.  This pull request also fixes #183, to get FLiT to work with GCC 4 and 5, which is a huge deal.  Now we also have automated regression to check for an older version of GCC with FLiT, which is awesome!

**Documentation:** nothing needing mention for this change.  The `documentation/installation.md` page already says that we support GCC 4.9 and greater.  That had actually been broken, but is now fixed.  The continuous integration system should be documented where it talks about how to contribute to the project, which doesn't yet exist.  For that, I made a new issue, #184.

**Tests:** many existing tests were updated to be more robust so that they can pas in the Travis CI environment.  No new functionality needs to be tested other than that.  It may be good to test Travis CI with other compilers such as clang and newer versions of GCC.