### PR TITLE
Issue120 custom compilers

### DIFF
--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -94,6 +94,9 @@ CLANG           := {clang_compiler}
 INTEL           := {intel_compiler}
 GCC             := {gcc_compiler}
 
+# keep only the compilers that are not None and are in the path
+COMPILERS       := {compilers}
+
 FLIT_INC_DIR    := {flit_include_dir}
 FLIT_LIB_DIR    := {flit_lib_dir}
 FLIT_DATA_DIR   := {flit_data_dir}
@@ -229,16 +232,6 @@ GT_DEPS          = $(GT_OBJ:%.o=%.d)
 # note: will return false if both $1 and $2 are empty
 equal            = $(and $(findstring $1,$2),$(findstring $2,$1))
 not_equal        = $(if $(call equal,$1,$2),,good)
-
-# keep only the compilers that are not None and are in the path
-COMPILERS       := $(foreach c, GCC INTEL CLANG, \
-                     $(if \
-                       $(and \
-                         $(call not_equal,None,$($(c))),\
-                         $(shell which $($(c)) 2>/dev/null)), $c,))
-$(foreach c, $(filter-out $(COMPILERS),GCC INTEL CLANG), \
-  $(if $(call not_equal,None,$($(c))), \
-    $(warning Warning: Could not find compiler $($(c)) of type $(c)),))
 
 HOSTNAME        := $(shell hostname)
 

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -89,6 +89,11 @@ GT_OUT          := ground-truth.csv
 
 UNAME_S         := $(shell uname -s)
 
+# will be None if not specified in flit-config.toml
+CLANG           := {clang_compiler}
+INTEL           := {intel_compiler}
+GCC             := {gcc_compiler}
+
 FLIT_INC_DIR    := {flit_include_dir}
 FLIT_LIB_DIR    := {flit_lib_dir}
 FLIT_DATA_DIR   := {flit_data_dir}
@@ -220,16 +225,17 @@ DEV_DEPS         = $(DEV_OBJ:%.o=%.d)
 GT_OBJ           = $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_gt.o)))
 GT_DEPS          = $(GT_OBJ:%.o=%.d)
 
-CLANG           := clang++
-INTEL           := icpc
-GCC             := g++
+# checks for string equality between $1 and $2
+# note: will return false if both $1 and $2 are empty
+equal            = $(and $(findstring $1,$2),$(findstring $2,$1))
+not_equal        = $(if $(call equal,$1,$2),,good)
 
-ifdef CLANG_ONLY
-COMPILERS       := CLANG
-else
+# keep only the compilers that are not None and are in the path
 COMPILERS       := $(foreach c, GCC INTEL CLANG, \
-                     $(if $(shell which $($(c)) 2>/dev/null), $c,))
-endif
+                     $(if \
+                       $(and \
+                         $(call not_equal,None,$($(c))),\
+                         $(shell which $($(c)) 2>/dev/null), $c,)))
 
 HOSTNAME        := $(shell hostname)
 

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -235,7 +235,10 @@ COMPILERS       := $(foreach c, GCC INTEL CLANG, \
                      $(if \
                        $(and \
                          $(call not_equal,None,$($(c))),\
-                         $(shell which $($(c)) 2>/dev/null), $c,)))
+                         $(shell which $($(c)) 2>/dev/null)), $c,))
+$(foreach c, $(filter-out $(COMPILERS),GCC INTEL CLANG), \
+  $(if $(call not_equal,None,$($(c))), \
+    $(warning Warning: Could not find compiler $($(c)) of type $(c)),))
 
 HOSTNAME        := $(shell hostname)
 
@@ -243,8 +246,11 @@ RESULTS_DIR     := results
 
 # on systems with non-standard gcc installations (such as module), clang may
 # be unable to determine the correct gcc toolchain
+CLANG_REQUIRED  :=
+ifeq ($(findstring GCC,$(COMPILERS)),GCC)
 GCC_TOOLCHAIN   := $(dir $(shell which $(GCC) 2>/dev/null))/..
-CLANG_REQUIRED  := --gcc-toolchain=$(GCC_TOOLCHAIN)
+CLANG_REQUIRED  += --gcc-toolchain=$(GCC_TOOLCHAIN)
+endif
 
 # Compiler setting targets
 #   taken from: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -228,11 +228,6 @@ DEV_DEPS         = $(DEV_OBJ:%.o=%.d)
 GT_OBJ           = $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_gt.o)))
 GT_DEPS          = $(GT_OBJ:%.o=%.d)
 
-# checks for string equality between $1 and $2
-# note: will return false if both $1 and $2 are empty
-equal            = $(and $(findstring $1,$2),$(findstring $2,$1))
-not_equal        = $(if $(call equal,$1,$2),,good)
-
 HOSTNAME        := $(shell hostname)
 
 RESULTS_DIR     := results

--- a/scripts/flitcli/config/flit-default.toml.in
+++ b/scripts/flitcli/config/flit-default.toml.in
@@ -140,13 +140,30 @@ optimization_level = '-O0'
 switches = ''
 
   # This host's list of compilers.
-  # For now, only used for hosts.ground_truth and hosts.dev_build.
-  # TODO: use this list to generate the Makefile
-  [[hosts.compilers]]
+  # - binary: can be an absolute path, relative path, or binary name (found in
+  #   PATH).  If you want to specify a compiler in the same directory as this
+  #   config file, prepend with a "./" (e.g. "./my-compiler")
+  # - name: can be any string.  Used to recognize in the other options such as
+  #   dev_build and ground_truth
+  # - type: the brand of the compiler.  We support ('gcc', 'clang', 'intel')
+  #   Currently, only one of each type may be specified.
+  # Note that these are all defaulted to use g++, clang++, and icpc from the
+  # PATH.
+  # If you specify any one compiler, then these defaults are erased.  If you
+  # specify no compiler, then these defaults take effect.
 
-  # binary can be an absolute path, relative path, or binary name (found in
-  # PATH).  If you want to specify a compiler in the same directory as this
-  # config file, prepend with a "./" (e.g. "./my-compiler")
+  [[hosts.compilers]]
   binary = 'g++'
   name = 'g++'
+  type = 'gcc'
+
+  [[hosts.compilers]]
+  binary = 'clang++'
+  name = 'clang++'
+  type = 'clang'
+
+  [[hosts.compilers]]
+  binary = 'icpc'
+  name = 'icpc'
+  type = 'intel'
 

--- a/scripts/flitcli/flit_update.py
+++ b/scripts/flitcli/flit_update.py
@@ -134,8 +134,8 @@ def main(arguments, prog=sys.argv[0]):
     assert len(matching_dev_compilers) < 2, \
             'Multiple compilers with name {0} found'.format(dev_compiler_name)
     dev_compiler_bin = matching_dev_compilers[0]['binary']
-    if '/' in dev_compiler_bin:
-        dev_compiler_bin = os.path.realpath(dev_compiler_bin)
+    #if '/' in dev_compiler_bin:
+    #    dev_compiler_bin = os.path.realpath(dev_compiler_bin)
 
     ground_truth = host['ground_truth']
     gt_compiler_name = ground_truth['compiler_name']
@@ -149,8 +149,8 @@ def main(arguments, prog=sys.argv[0]):
             'Multiple compilers with name {0} found'.format(gt_compiler_names)
     # TODO: use the compiler mnemonic rather than the path
     gt_compiler_bin = matching_gt_compilers[0]['binary']
-    if '/' in dev_compiler_bin:
-        gt_compiler_bin = os.path.realpath(gt_compiler_bin)
+    #if '/' in dev_compiler_bin:
+    #    gt_compiler_bin = os.path.realpath(gt_compiler_bin)
 
     supported_compiler_types = ('clang', 'gcc', 'intel')
     base_compilers = {x: None for x in supported_compiler_types}

--- a/scripts/flitcli/flit_update.py
+++ b/scripts/flitcli/flit_update.py
@@ -170,6 +170,8 @@ def main(arguments, prog=sys.argv[0]):
             '--timing-repeats', str(projconf['run']['timing_repeats']),
             ])
 
+    given_compilers = [key.upper() for key, val in base_compilers.items()
+                       if val is not None]
     replacements = {
         'dev_compiler': dev_compiler_bin,
         'dev_optl': dev_optl,
@@ -185,6 +187,7 @@ def main(arguments, prog=sys.argv[0]):
         'test_run_args': test_run_args,
         'enable_mpi': 'yes' if projconf['run']['enable_mpi'] else 'no',
         'mpirun_args': projconf['run']['mpirun_args'],
+        'compilers': ' '.join(given_compilers),
         }
     replacements.update({key + '_compiler': val
                          for key, val in base_compilers.items()})


### PR DESCRIPTION
Addresses the first pass of issue #120, but not the whole thing.  This pull request allows the user to specify at most one of each type of compiler.  Supported types are `('gcc', 'clang', 'intel')`.

This pull request does not add any tests or documentation (besides what is put into the default `flit-config.toml`).

**Note:** this is a breaking change in that configuration files that specify only one compiler will only have FLiT search over that one compiler.  Be warned about this change for that reason.  You may need to update your `flit-config.toml` to  specify all compilers you want to use.