### PR TITLE
test_harness: fixed tempdir() deletion on raised exception

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,6 +4,7 @@ CFLAGS        += -std=c++11
 LDFLAGS       :=
 TESTER_SRC    := harness_tester.cpp
 HARNESS       := test_harness.h
+HARNESS_PY    := test_harness.py
 TESTER        := $(TESTER_SRC:%.cpp=%)
 SUB_MAKES     := $(wildcard */Makefile */makefile)
 SUB_DIRS      := $(patsubst %/,%,$(dir $(SUB_MAKES)))
@@ -16,7 +17,7 @@ build: $(TESTER) $(BUILD_TARGETS)
 
 include color_out.mk
 
-check: run__$(TESTER) $(CHECK_TARGETS)
+check: run__$(TESTER) run_tester_py $(CHECK_TARGETS)
 	@$(call color_out,GREEN,All tests pass)
 
 help:
@@ -29,8 +30,16 @@ help:
 clean: $(CLEAN_TARGETS)
 	rm -f $(TESTER)
 
+.PHONY: run_tester_py
+run_tester_py: $(HARNESS_PY)
+	@$(call color_out_noline,BROWN,  testing)
+	@echo " $(HARNESS_PY)"
+	@python3 -m doctest $(HARNESS_PY)
+
 .PHONY: run__% build__% check__% clean__%
 run__$(TESTER): $(TESTER)
+	@$(call color_out_noline,BROWN,  testing)
+	@echo " $(HARNESS)"
 	@./$(TESTER) | grep "failures: *10" >/dev/null
 
 build__%:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -185,24 +185,37 @@ def tempdir(*args, **kwargs):
     ...     print(os.path.isdir(temporary_directory))
     ...
     True
-    >>> print(os.path.isdir(temporary_directory))
+    >>> os.path.isdir(temporary_directory)
     False
-    >>> print(os.path.exists(temporary_directory))
+    >>> os.path.exists(temporary_directory)
     False
 
     Test that an exception is not thrown if it was already deleted
     >>> import shutil
     >>> with tempdir() as new_dir:
     ...     shutil.rmtree(new_dir)
+
+    Test that the directory is still deleted even if an exception is thrown
+    within the with statement.
+    >>> try:
+    ...     with tempdir() as new_dir:
+    ...         temporary_directory = new_dir
+    ...         raise RuntimeError()
+    ... except:
+    ...     pass
+    >>> os.path.isdir(temporary_directory)
+    False
     '''
     import tempfile
     import shutil
     new_dir = tempfile.mkdtemp(*args, **kwargs)
-    yield new_dir
     try:
-        shutil.rmtree(new_dir)
-    except FileNotFoundError:
-        pass
+        yield new_dir
+    finally:
+        try:
+            shutil.rmtree(new_dir)
+        except FileNotFoundError:
+            pass
 
 def touch(filename):
     '''


### PR DESCRIPTION
Fixes #220 

**Description of changes**
The `yield` statement within the `tempdir()` function is supposed to be within a `try..finally` block so that the rest is run in the case of an exception.  This was added.

**Documentation**
No changes necessary, as it was fixing intended behavior

**Tests**
Added one test case in the docstring of `tempdir()` that fails without this change, and passes afterwards.  I added the running of docstrings from `test_harness.py` to `tests/Makefile` on the `make check` target, so this added test will be run every time.