### PR TITLE
Issue211 import broke mpi test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,20 +98,20 @@ matrix:
             - *native_deps
             - libopenmpi-dev
             - openmpi-bin
-    # Job 2: No MPI
+    # Job 2: MPICH
+    #- env: mpi_type=mpich
+    #  addons:
+    #    apt:
+    #      packages:
+    #        - *native_deps
+    #        - libmpich-dev
+    #        - mpich
+    # Job 3: No MPI
     - env: mpi_type=none
       addons:
         apt:
           packages:
             - *native_deps
-    # Job 3: MPICH
-    - env: mpi_type=mpich
-      addons:
-        apt:
-          packages:
-            - *native_deps
-            - libmpich-dev
-            - mpich
 
 before_install: pip3 install --user toml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,23 @@ addons:
     packages:
       - python3
       - python3-pip
-      - openmpi-bin
-      - libopenmpi-dev
+
+matrix:
+  include:
+    # Job 1: OpenMPI
+    - addons:
+        apt:
+          packages:
+            - libopenmpi-dev
+            - openmpi-bin
+    # Job 2: No MPI
+    - env: DUMMY=1 # no MPI installed
+    # Job 3: MPICH
+    - addons:
+        apt:
+          packages:
+            - libmpich-dev
+            - mpich
 
 before_install: pip3 install --user toml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,24 +84,32 @@ language: cpp
 os: linux
 addons:
   apt:
-    packages:
+    packages: &native_deps
       - python3
       - python3-pip
 
 matrix:
   include:
     # Job 1: OpenMPI
-    - addons:
+    - env: mpi_type=openmpi
+      addons:
         apt:
           packages:
+            - *native_deps
             - libopenmpi-dev
             - openmpi-bin
     # Job 2: No MPI
-    - env: DUMMY=1 # no MPI installed
-    # Job 3: MPICH
-    - addons:
+    - env: mpi_type=none
+      addons:
         apt:
           packages:
+            - *native_deps
+    # Job 3: MPICH
+    - env: mpi_type=mpich
+      addons:
+        apt:
+          packages:
+            - *native_deps
             - libmpich-dev
             - mpich
 

--- a/tests/flit_mpi/Makefile
+++ b/tests/flit_mpi/Makefile
@@ -1,11 +1,21 @@
 RUNNER      := python3
 SRC         := $(wildcard tst_*.py)
 RUN_TARGETS := $(SRC:%.py=run_%)
+MPIRUN      := $(shell command -v mpirun 2>/dev/null)
+MPICXX      := $(shell command -v mpic++ 2>/dev/null)
 
 include ../color_out.mk
 
 .PHONY: check help clean build run_%
+ifeq ($(MPIRUN),)
+check:
+	$(call color_out,RED,Warning: mpirun is not found on your system; skipping the MPI tests)
+else ifeq ($(MPICXX),)
+check:
+	$(call color_out,RED,Warning: mpic++ is not found on your system; skipping the MPI tests)
+else
 check: $(TARGETS) $(RUN_TARGETS)
+endif
 
 help:
 	@echo "Makefile for running tests on FLiT framework"


### PR DESCRIPTION
Fixes #211, at least the problem introduced in fixing that issue.

**Description of problem**
The last pull request #215 based on issue #211 broke one aspect of the tests.  When an MPI framework is not installed on the system, the MPI tests are supposed to be skipped.  This was broken in reworking the `tests/flit_mpi/Makefile`.

**Description of change**
Many of the changes from pull request #215 have been reverted for `tests/flit_mpi/Makefile` to restore the functionality of skipping MPI tests when MPI is not installed.

**Documentation**
Not necessary, as this returns things to intended functionality

**Tests**
This is a fix to the tests.  However, there was not an automated test that checks to see if the tests work when MPI is not installed.  That has now been added to Travis-CI.

In fact, within the detailed report from Travis-CI for this pull-request, look at how there are two subjobs within the Travis-CI run.  One is for OpenMPI and the other is for no MPI installed at all.  Cool, huh?