### PR TITLE
Issue225 bisect assert disjoint

### DIFF
--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1582,6 +1582,11 @@ def run_bisect(arguments, prog=sys.argv[0]):
                     logging.info('%s', message)
 
     differing_symbols.sort(key=lambda x: (-x[1], x[0]))
+    all_searched_symbols = extract_symbols([x[0] for x in differing_sources],
+                                           os.path.join(args.directory, 'obj'))
+    checker = _gen_bisect_symbol_checker(
+        args, bisect_path, replacements, sources, all_searched_symbols)
+    assert checker(all_searched_symbols) == checker([x[0] for x in differing_symbols])
 
     if args.biggest is None:
         print('All variability inducing symbols:')

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -546,7 +546,7 @@ def memoize_strlist_func(func):
     memo = {}
     def memoized_func(strlist):
         'func but memoized'
-        idx = tuple(strlist)
+        idx = tuple(sorted(strlist))
         if idx in memo:
             return memo[idx]
         value = func(strlist)

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -782,6 +782,8 @@ def bisect_search(score_func, elements, found_callback=None):
         list(set(elements).difference(x[0] for x in differing_list))
     assert score_func(non_differing_list) <= 0, \
         'Assumption that differing elements are independent was wrong'
+    assert score_func(elements) == score_func([x[0] for x in differing_list]),\
+        'Assumption that minimal sets are non-overlapping was wrong'
 
     # sort descending by score
     differing_list.sort(key=lambda x: -x[1])

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -442,6 +442,7 @@ attributes:
     lineno:     line number of definition within fname.
 '''
 
+_extract_symbols_memos = {}
 def extract_symbols(file_or_filelist, objdir):
     '''
     Extracts symbols for the given file(s) given.  The corresponding object is
@@ -467,6 +468,9 @@ def extract_symbols(file_or_filelist, objdir):
     fname = file_or_filelist
     fbase = os.path.splitext(os.path.basename(fname))[0]
     fobj = os.path.join(objdir, fbase + '_gt.o')
+
+    if fobj in _extract_symbols_memos:
+        return _extract_symbols_memos[fobj]
 
     # use nm and objdump to get the binary information we need
     symbol_strings = subp.check_output([
@@ -517,6 +521,7 @@ def extract_symbols(file_or_filelist, objdir):
         symbol_tuples.append(
             SymbolTuple(fname, symbol, demangled, deffile, defline))
 
+    _extract_symbols_memos[fobj] = symbol_tuples
     return symbol_tuples
 
 def memoize_strlist_func(func):

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -537,16 +537,16 @@ def memoize_strlist_func(func):
     >>> memoized = memoize_strlist_func(to_memoize)
     >>> memoized(['a', 'b', 'c'])
     ['a', 'b', 'c']
-    a
+    'a'
     >>> memoized(['a', 'b', 'c'])
-    a
+    'a'
     >>> memoized(['e', 'a'])
     ['e', 'a']
-    e
+    'e'
     >>> memoized(['a', 'b', 'c'])
-    a
+    'a'
     >>> memoized(['e', 'a'])
-    e
+    'e'
     '''
     memo = {}
     def memoized_func(strlist):
@@ -715,7 +715,7 @@ def bisect_search(score_func, elements, found_callback=None):
     score_func(), so we are only counting unique calls and not duplicate calls
     to score_func().
     >>> call_count
-    9
+    10
 
     Test out the found_callback() functionality.
     >>> s = set()

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1581,12 +1581,17 @@ def run_bisect(arguments, prog=sys.argv[0]):
                     print(message)
                     logging.info('%s', message)
 
+        # Verify that there are no missed files, i.e. those that are more than
+        # singletons and that are to be grouped with one of the found symbols.
+        all_searched_symbols = extract_symbols(
+            [x[0] for x in differing_sources],
+            os.path.join(args.directory, 'obj'))
+        checker = _gen_bisect_symbol_checker(
+            args, bisect_path, replacements, sources, all_searched_symbols)
+        assert checker(all_searched_symbols) == \
+               checker([x[0] for x in differing_symbols])
+
     differing_symbols.sort(key=lambda x: (-x[1], x[0]))
-    all_searched_symbols = extract_symbols([x[0] for x in differing_sources],
-                                           os.path.join(args.directory, 'obj'))
-    checker = _gen_bisect_symbol_checker(
-        args, bisect_path, replacements, sources, all_searched_symbols)
-    assert checker(all_searched_symbols) == checker([x[0] for x in differing_symbols])
 
     if args.biggest is None:
         print('All variability inducing symbols:')

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1670,7 +1670,7 @@ def run_bisect(arguments, prog=sys.argv[0]):
                     print(message)
                     logging.info('%s', message)
 
-        if not args.skip_verification:
+        if not args.skip_verification and len(differing_sources) > 1:
             # Verify that there are no missed files, i.e. those that are more
             # than singletons and that are to be grouped with one of the found
             # symbols.

--- a/tests/flit_cli/flit_bisect/tst_bisect.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect.py
@@ -175,7 +175,7 @@ Verify the differing symbols section for file3.cpp
 >>> print('\\n'.join(bisect_out[idx+1:idx+3]))
     line 103 -- file3_func5_PROBLEM() (score 3.0)
     line 92 -- file3_func2_PROBLEM() (score 1.0)
->>> bisect_out[idx+3].startswith(' ')
+>>> bisect_out[idx+3].startswith('    ')
 False
 
 Test the All differing symbols section of the output

--- a/tests/flit_cli/flit_bisect/tst_bisect_biggest.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect_biggest.py
@@ -235,7 +235,7 @@ Looking for the top 1 different symbol(s) by starting with files
       Created ...
       ...
         Found differing symbol on line 90 -- file2_func1_PROBLEM() (score 7.0)
-    Found differing source file tests/file3.cpp: score 4.0
+ ...Found differing source file tests/file3.cpp: score 4.0
 The found highest variability inducing source files:
   tests/file1.cpp (score 10.0)
   tests/file2.cpp (score 7.0)
@@ -259,7 +259,7 @@ Looking for the top 2 different symbol(s) by starting with files
       Created ...
       ...
         Found differing symbol on line 90 -- file2_func1_PROBLEM() (score 7.0)
-    Found differing source file tests/file3.cpp: score 4.0
+ ...Found differing source file tests/file3.cpp: score 4.0
 The found highest variability inducing source files:
   tests/file1.cpp (score 10.0)
   tests/file2.cpp (score 7.0)


### PR DESCRIPTION
Fixes #225

**Description:**
Many changes to bisect:

- Sort the list in the memoization, so that list ordering does not cause tests to be unnecessarily executed
- Add the suggested extra assertion within `bisect_search()`
- Add assertions into the `bisect_biggest()` function as well, only if all variable elements are found
- Add assertion after all symbols from all files have been found
- Add `--skip-verification` flag to skip the verification assertions (lessen the number of test executions)

**Documentation:**
I did not change any documentation.  The functionality I changed is not currently in the documentation.  It should be added to the documentation, but that is in the scope of issue #136.

**Tests:**

- Added tests for this new functionality within the docstring for `bisect_search()` and `bisect_biggest()`.
- Fixed the test `tst_bisect_biggest.py`
