### PR TITLE
Issue229 bisect deadlock

### DIFF
--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -332,6 +332,9 @@ def run_make(makefilename='Makefile', directory='.', verbose=False,
             else:
                 ps = subp.Popen(command, stdout=subp.PIPE, stderr=subp.STDOUT)
                 subp.check_call(['tee', tmpout.name], stdin=ps.stdout)
+                ps.communicate()
+                if ps.returncode != 0:
+                    raise subp.CalledProcessError(ps.returncode, command)
         except:
             tmpout.flush()
             with open(tmpout.name, 'r') as tmpin:

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1836,7 +1836,9 @@ def auto_bisect_worker(arg_queue, result_queue):
         pass
 
     except:
+        # without putting something onto the result_queue, the parent process will deadlock
         result_queue.put((row, -1, None, None, None, 1))
+        raise
 
 def parallel_auto_bisect(arguments, prog=sys.argv[0]):
     '''

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -256,10 +256,93 @@ def create_bisect_makefile(directory, replacements, gt_src,
 
     return makefile
 
+def run_make(makefilename='Makefile', directory='.', verbose=False,
+             jobs=mp.cpu_count(), target=None):
+    '''
+    Runs a make command.  If the build fails, then stdout and stderr will be
+    output into the log.
+
+    @param makefilename: Name of the Makefile (default 'Makefile')
+    @param directory: Path to the directory to run in (default '.')
+    @param verbose: True means echo the output to the console (default False)
+    @param jobs: number of parallel jobs (default #cpus)
+    @param target: Makefile target to build (defaults to GNU Make's default)
+
+    @return None
+
+    @throws subprocess.CalledProcessError on failure
+
+    Configure the logger to spit to stdout instead of stderr
+    >>> import logging
+    >>> logger = logging.getLogger()
+    >>> for handler in logger.handlers[:]:
+    ...     logger.removeHandler(handler)
+    >>> import sys
+    >>> logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    Make sure the exception is thrown
+    >>> with NamedTemporaryFile(mode='w') as tmpmakefile:
+    ...     print('.PHONY: default\\n', file=tmpmakefile)
+    ...     print('default:\\n', file=tmpmakefile)
+    ...     print('\\t@echo hello\\n', file=tmpmakefile)
+    ...     print('\\t@false\\n', file=tmpmakefile)
+    ...     tmpmakefile.flush()
+    ...
+    ...     run_make(makefilename=tmpmakefile.name) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+      ...
+    subprocess.CalledProcessError: Command ... returned non-zero exit status 2.
+
+    See what was output to the logger
+    >>> with NamedTemporaryFile(mode='w') as tmpmakefile:
+    ...     print('.PHONY: default\\n', file=tmpmakefile)
+    ...     print('default:\\n', file=tmpmakefile)
+    ...     print('\\t@echo hello\\n', file=tmpmakefile)
+    ...     print('\\t@false\\n', file=tmpmakefile)
+    ...     tmpmakefile.flush()
+    ...
+    ...     try:
+    ...         run_make(makefilename=tmpmakefile.name) #doctest: +ELLIPSIS
+    ...     except:
+    ...         pass
+    ERROR:root:make error occurred.  Here is the output:
+    make: Entering directory `...'
+    hello
+    make: *** [default] Error 1
+    make: Leaving directory `...'
+    <BLANKLINE>
+
+    Undo the logger configurations
+    >>> for handler in logger.handlers[:]:
+    ...     logger.removeHandler(handler)
+    '''
+    command = [
+        'make',
+        '-C', directory,
+        '-f', makefilename,
+        '-j', str(jobs),
+        ]
+    if target is not None:
+        command.append(target)
+
+    with NamedTemporaryFile() as tmpout:
+        try:
+            if not verbose:
+                subp.check_call(command, stdout=tmpout, stderr=subp.STDOUT)
+            else:
+                ps = subp.Popen(command, stdout=subp.PIPE, stderr=subp.STDOUT)
+                subp.check_call(['tee', tmpout.name], stdin=ps.stdout)
+        except:
+            tmpout.flush()
+            with open(tmpout.name, 'r') as tmpin:
+                logging.error('make error occurred.  Here is the output:\n' +
+                              tmpin.read())
+            raise
+
 def build_bisect(makefilename, directory,
                  target='bisect',
                  verbose=False,
-                 jobs=None):
+                 jobs=mp.cpu_count()):
     '''
     Creates the bisect executable by executing a parallel make.
 
@@ -278,35 +361,12 @@ def build_bisect(makefilename, directory,
     @return None
     '''
     logging.info('Building the bisect executable')
-    if jobs is None:
-        jobs = mp.cpu_count()
-    kwargs = dict()
-
-    command = [
-        'make',
-        '-C', directory,
-        '-f', makefilename,
-        '-j', str(jobs),
-        target,
-        ]
-
-    with NamedTemporaryFile() as tmpout:
-        try:
-            if not verbose:
-                kwargs['stdout'] = tmpout
-                kwargs['stderr'] = tmpout
-                subp.check_call(command, stdout=tmpout, stderr=subp.STDOUT)
-            else:
-                ps = subp.Popen(command, stdout=subp.PIPE, stderr=subp.STDOUT)
-                command = ['tee']
-                subp.check_call(['tee', tmpout.name], stdin=ps.stdout)
-        except:
-            tmpout.flush()
-            with open(tmpout.name, 'r') as tmpin:
-                logging.error('make error occurred.  Here is the output:\n' +
-                              tmpin.read())
-            raise
-
+    run_make(
+        makefilename=makefilename,
+        directory=directory,
+        verbose=verbose,
+        jobs=jobs,
+        target=target)
 
 def update_gt_results(directory, verbose=False,
                       jobs=mp.cpu_count(), fpic=False):
@@ -316,20 +376,26 @@ def update_gt_results(directory, verbose=False,
 
     @param directory: where to execute make
     @param verbose: False means block output from GNU make and running
+    @param jobs: number of parallel jobs (default #cpus)
+    @param fpic: True means compile the gt-fpic files too (default False)
+
+    @return None
     '''
-    kwargs = dict()
-    if not verbose:
-        kwargs['stdout'] = subp.DEVNULL
-        kwargs['stderr'] = subp.DEVNULL
     gt_resultfile = util.extract_make_var(
         'GT_OUT', os.path.join(directory, 'Makefile'))[0]
     logging.info('Updating ground-truth results - %s', gt_resultfile)
     print('Updating ground-truth results -', gt_resultfile, end='', flush=True)
-    subp.check_call(
-        ['make', '-j', str(jobs), '-C', directory, gt_resultfile], **kwargs)
+    run_make(
+        directory=directory,
+        verbose=verbose,
+        jobs=jobs,
+        target=gt_resultfile)
     if fpic:
-        subp.check_call(
-            ['make', '-j', str(jobs), '-C', directory, 'gt-fpic'], **kwargs)
+        run_make(
+            directory=directory,
+            verbose=verbose,
+            jobs=jobs,
+            target='gt-fpic')
     print(' - done')
     logging.info('Finished Updating ground-truth results')
 
@@ -1423,8 +1489,11 @@ def compile_trouble(directory, compiler, optl, switches, verbose=False,
 
     # see if the Makefile needs to be regenerated
     # we use the Makefile to check for itself, sweet
-    subp.check_call(['make', '-C', directory, 'Makefile'],
-                    stdout=subp.DEVNULL, stderr=subp.DEVNULL)
+    run_make(
+        directory=directory,
+        verbose=verbose,
+        jobs=1,
+        target='Makefile')
 
     # trouble compilations all happen in the same directory
     trouble_path = os.path.join(directory, 'bisect-precompile')
@@ -1484,8 +1553,8 @@ def run_bisect(arguments, prog=sys.argv[0]):
 
     # see if the Makefile needs to be regenerated
     # we use the Makefile to check for itself, sweet
-    subp.check_call(['make', '-C', args.directory, 'Makefile'],
-                    stdout=subp.DEVNULL, stderr=subp.DEVNULL)
+    run_make(directory=args.directory, verbose=verbose, jobs=1,
+             target='Makefile')
 
     # create a unique directory for this bisect run
     bisect_dir = create_bisect_dir(args.directory)
@@ -1836,8 +1905,8 @@ def parallel_auto_bisect(arguments, prog=sys.argv[0]):
 
     # see if the Makefile needs to be regenerated
     # we use the Makefile to check for itself, sweet
-    subp.check_call(['make', '-C', args.directory, 'Makefile'],
-                    stdout=subp.DEVNULL, stderr=subp.DEVNULL)
+    run_make(directory==args.directory, verbose=verbose, jobs=1,
+             target='Makefile')
 
     print('Before parallel bisect run, compile all object files')
     for i, compilation in enumerate(sorted(compilation_set)):

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1553,7 +1553,7 @@ def run_bisect(arguments, prog=sys.argv[0]):
 
     # see if the Makefile needs to be regenerated
     # we use the Makefile to check for itself, sweet
-    run_make(directory=args.directory, verbose=verbose, jobs=1,
+    run_make(directory=args.directory, verbose=args.verbose, jobs=1,
              target='Makefile')
 
     # create a unique directory for this bisect run
@@ -1905,7 +1905,7 @@ def parallel_auto_bisect(arguments, prog=sys.argv[0]):
 
     # see if the Makefile needs to be regenerated
     # we use the Makefile to check for itself, sweet
-    run_make(directory==args.directory, verbose=verbose, jobs=1,
+    run_make(directory=args.directory, verbose=args.verbose, jobs=1,
              target='Makefile')
 
     print('Before parallel bisect run, compile all object files')

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -1766,6 +1766,9 @@ def auto_bisect_worker(arg_queue, result_queue):
         # exit the function
         pass
 
+    except:
+        result_queue.put((row, -1, None, None, None, 1))
+
 def parallel_auto_bisect(arguments, prog=sys.argv[0]):
     '''
     Runs bisect in parallel under the auto mode.  This is only applicable if


### PR DESCRIPTION
Partially Fixes #229 

**Description:**

- Every call to `make` from `flit bisect` is not in a consolidated function called `run_make()`.  This function will output the standard out and error to the log in the case of an error.
- For any uncaught exception, the child process will put in an empty result into the result queue, allowing progress by the parent process when in `--auto-sqlite-run` mode.

**Documentation:**
No documentation update necessary.  This was fixing existing functionality.

**Tests:**
- Added some automated tests to `run_make()` within the docstring there.
- **Still need** automated tests demonstrating the deadlock situation to provide regression.  For this reason, the issue will not be closed yet with this pull request.  Another pull request will be coming with that automated test.
