### PR TITLE
issue230 Make with missing headers

### DIFF
--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -186,7 +186,7 @@ IS_GCC_4_OR_5    = $(shell expr $(call IS_GCC,$1) \& \
 DEV_LDFLAGS      =
 GT_LDFLAGS       =
 
-DEPFLAGS        += -MMD -MF $(patsubst %.o,%.d,$@)
+DEPFLAGS        += -MMD -MP -MF $(patsubst %.o,%.d,$@)
 
 TESTS            = $(wildcard tests/*.cpp)
 SOURCE           = $(wildcard *.cpp)


### PR DESCRIPTION
Partially Fixes #230

**Description:**
Added `-MP` to the `DEPFLAGS` variable within `data/Makefile.in`.  This allows for the autogenerated dependency files (with the `.d` ending) to have empty rules for each header file.  The result is that if the header files are missing, GNU Make will no longer throw an error.

**Documentation:**
No document change necessary.  This is internal functionality.

**Tests:**
No tests were added.  I think there should be an automated test added that demonstrates this problem, to both prove that the problem is fixed, and to provide regression.  For this reason, issue #230 will not yet be closed and another pull request for that issue will still be pending.
