### PR TITLE
Specify the minimum version of binutils

### DIFF
--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -18,7 +18,7 @@ Instruction Contents:
 Stuff you should already have:
 
 * [bash](https://www.gnu.org/software/bash)
-* [binutils](https://www.gnu.org/software/binutils)
+* [binutils](https://www.gnu.org/software/binutils) version 2.26 or higher
 * [coreutils](https://www.gnu.org/software/coreutils/coreutils.html)
 * hostname
 


### PR DESCRIPTION
Fixes #233 

**Description:**
Update the documentation to specify the minimum version of binutils to 2.26

**Documentation:**
Updated the version of binutils only.

**Tests:**
None needed.