### PR TITLE
Basic Fortran support 

### DIFF
--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -98,17 +98,27 @@ GCC_TYPE        := gcc
 # keep only the compilers that are not None and are in the path
 COMPILERS       := {compilers}
 
+COLLECTIONS     := {comipler_collections}
+
+{compiler_collection_compilers}
+# E.G. if GCC was the collection
+#
+# GCC_CXX = g++
+# GCC_FXX = gfortran
+
 FLIT_INC_DIR    := {flit_include_dir}
 FLIT_LIB_DIR    := {flit_lib_dir}
 FLIT_DATA_DIR   := {flit_data_dir}
 FLIT_SCRIPT_DIR := {flit_script_dir}
 
-DEV_CXX         ?= {dev_compiler}
+DEV_COLLECTION  ?= {dev_compiler_collection}
+DEV_CXX         ?= $(DEV_COLLECTION)_CXX
 DEV_CXX_TYPE    ?= {dev_type}
 DEV_OPTL        ?= {dev_optl}
 DEV_SWITCHES    ?= {dev_switches}
 
-GT_CXX          := {ground_truth_compiler}
+GT_COLLECTION   := {ground_truth_compiler_collection}
+GT_CXX          := $(GT_COLLECTION)_CXX
 GT_CXX_TYPE     := {ground_truth_type}
 GT_OPTL         := {ground_truth_optl}
 GT_SWITCHES     := {ground_truth_switches}
@@ -139,6 +149,8 @@ CC_REQUIRED     += -fno-pie
 CC_REQUIRED     += -std=c++11
 CC_REQUIRED     += -I.
 CC_REQUIRED     += -I$(FLIT_INC_DIR)
+
+F_REQUIRED      := 
 
 DEV_CFLAGS      += -g
 DEV_CFLAGS      += -Wall
@@ -187,6 +199,7 @@ DEPFLAGS        += -MMD -MP -MF $(patsubst %.o,%.d,$@)
 TESTS            = $(wildcard tests/*.cpp)
 SOURCE           = $(wildcard *.cpp)
 SOURCE          += $(TESTS)
+F_SOURCE         = $(wildcard *.f90)
 
 VPATH            = $(dir $(SOURCE))
 
@@ -220,8 +233,10 @@ help:
 VPATH           := $(sort $(VPATH))
 
 DEV_OBJ          = $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_dev.o)))
+DEV_OBJ         += $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.f90=%_dev.o)))
 DEV_DEPS         = $(DEV_OBJ:%.o=%.d)
 GT_OBJ           = $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_gt.o)))
+GT_OBJ          += $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.f90=%_gt.o)))
 GT_DEPS          = $(GT_OBJ:%.o=%.d)
 GT_OBJ_FPIC      = $(GT_OBJ:%.o=%_fPIC.o)
 
@@ -265,7 +280,7 @@ endif
 
 # will be set internally when doing recursive calls.  Get set to variable names
 # containing the information (e.g. R_CUR_COMPILER=CLANG)
-R_CUR_COMPILER  ?=
+R_CUR_COLLECTION  ?=
 R_CUR_OPTL      ?=
 R_CUR_SWITCHES  ?=
 
@@ -275,6 +290,7 @@ ifdef R_IS_RECURSED
 R_ID            := $(R_CUR_COMPILER)_$(HOSTNAME)_$(R_CUR_SWITCHES)_$(R_CUR_OPTL)
 R_TARGET        := $(RESULTS_DIR)/$(R_ID)
 R_OBJ           := $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_$(R_ID).o)))
+R_OBJ           += $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.f90=%_$(R_ID).o)))
 R_DEP           := $(R_OBJ:%.o=%.d)
 
 -include $(R_DEP)
@@ -294,22 +310,32 @@ endif
 endif
 
 $(R_TARGET): $(R_OBJ)
-	$($(R_CUR_COMPILER)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
+	$($($(R_CUR_COLLECTION)_CXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
 	  $($(R_CUR_COMPILER)_REQUIRED) $(CC_REQUIRED) \
 	  $(R_OBJ) -o $@ \
 	  $(LD_REQUIRED)
-
+#if fortran, change cpp to fortran
 $(OBJ_DIR)/%_$(R_ID).o: %.cpp Makefile custom.mk | $(OBJ_DIR)
-	$($(R_CUR_COMPILER)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
-	  -c $($(R_CUR_COMPILER)_REQUIRED) $(CC_REQUIRED) \
+	$($($(R_CUR_COLLECTION)_CXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
+	  -c $($($(R_CUR_COLLECTION)_CXX)_REQUIRED) $(F_REQUIRED) \
 	  $< -o $@ \
 	  $(DEPFLAGS) \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
-	  -DFLIT_COMPILER='"$($(R_CUR_COMPILER))"' \
+	  -DFLIT_COMPILER='"$($($(R_CUR_COLLECTION)_CXX))"' \
 	  -DFLIT_OPTL='"$($(R_CUR_OPTL))"' \
 	  -DFLIT_SWITCHES='"$($(R_CUR_SWITCHES))"' \
 	  -DFLIT_FILENAME='"$(R_ID)"'
 
+$(OBJ_DIR)/%_$(R_ID).o: %.f90 Makefile custom.mk | $(OBJ_DIR)
+	$($($(R_CUR_COLLECTION)_FXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
+	  -c $($($(R_CUR_COLLECTION)_FXX)_REQUIRED) $(CC_REQUIRED) \
+	  $< -o $@ \
+	  $(DEPFLAGS) \
+	  -DFLIT_HOST='"$(HOSTNAME)"' \
+	  -DFLIT_COMPILER='"$($($(R_CUR_COLLECTION)_FXX))"' \
+	  -DFLIT_OPTL='"$($(R_CUR_OPTL))"' \
+	  -DFLIT_SWITCHES='"$($(R_CUR_SWITCHES))"' \
+	  -DFLIT_FILENAME='"$(R_ID)"'
 # Otherwise, we're not in a recursion.
 else # ifndef R_IS_RECURSED
 
@@ -362,16 +388,16 @@ TARGETS     += $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
 $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2): $$(GT_TARGET) | $$(OBJ_DIR) $$(RESULTS_DIR)
 	-$$(MAKE) rec \
 	  R_IS_RECURSED=True \
-	  R_CUR_COMPILER=$(strip $1) \
+	  R_CUR_COLLECTION=$(strip $1) \
 	  R_CUR_OPTL=$(strip $2) \
 	  R_CUR_SWITCHES=$(strip $3)
 	-test -f $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
 
 endef
 
-$(foreach c, $(COMPILERS),                 \
-  $(foreach s, $(SWITCHES_$(strip $c)),    \
-    $(foreach o, $(OPCODES_$(strip $c)),               \
+$(foreach c, $(COLLECTIONS),                 \
+  $(foreach s, $(SWITCHES_$(strip $($(c)_CXX))),    \
+    $(foreach o, $(OPCODES_$(strip $($(c)_CXX))),               \
       $(eval $(call RECURSION_RULE, $c, $o, $s)))))
 TARGET_OUTS     := $(TARGETS:%=%-out)
 TARGET_RESULTS  := $(TARGET_OUTS:%=%-comparison.csv)

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -98,13 +98,16 @@ GCC_TYPE        := gcc
 # keep only the compilers that are not None and are in the path
 COMPILERS       := {compilers}
 
-COLLECTIONS     := {comipler_collections}
-
-{compiler_collection_compilers}
+# Compiler Colections
+# 
 # E.G. if GCC was the collection
 #
 # GCC_CXX = g++
 # GCC_FXX = gfortran
+
+{collection_defs}
+
+COLLECTIONS     := {collections}
 
 FLIT_INC_DIR    := {flit_include_dir}
 FLIT_LIB_DIR    := {flit_lib_dir}
@@ -112,13 +115,13 @@ FLIT_DATA_DIR   := {flit_data_dir}
 FLIT_SCRIPT_DIR := {flit_script_dir}
 
 DEV_COLLECTION  ?= {dev_compiler_collection}
-DEV_CXX         ?= $(DEV_COLLECTION)_CXX
+DEV_CXX         ?= $($($(DEV_COLLECTION)_CXX))
 DEV_CXX_TYPE    ?= {dev_type}
 DEV_OPTL        ?= {dev_optl}
 DEV_SWITCHES    ?= {dev_switches}
 
 GT_COLLECTION   := {ground_truth_compiler_collection}
-GT_CXX          := $(GT_COLLECTION)_CXX
+GT_CXX          := $($($(GT_COLLECTION)_CXX))
 GT_CXX_TYPE     := {ground_truth_type}
 GT_OPTL         := {ground_truth_optl}
 GT_SWITCHES     := {ground_truth_switches}
@@ -130,6 +133,8 @@ MPIRUN_ARGS     := {mpirun_args}
 
 # initalize some variables to be appended later
 CC_REQUIRED     :=
+F_REQUIRED      :=
+F_FIX_REQUIRED  :=
 DEV_CFLAGS      :=
 LD_REQUIRED     :=
 
@@ -150,7 +155,7 @@ CC_REQUIRED     += -std=c++11
 CC_REQUIRED     += -I.
 CC_REQUIRED     += -I$(FLIT_INC_DIR)
 
-F_REQUIRED      := 
+F_REQUIRED      += -cpp
 
 DEV_CFLAGS      += -g
 DEV_CFLAGS      += -Wall
@@ -202,6 +207,7 @@ SOURCE          += $(TESTS)
 F_SOURCE         = $(wildcard *.f90)
 
 VPATH            = $(dir $(SOURCE))
+VPATH           += $(dir $(F_SOURCE))
 
 .PHONY: help
 help:
@@ -233,10 +239,10 @@ help:
 VPATH           := $(sort $(VPATH))
 
 DEV_OBJ          = $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_dev.o)))
-DEV_OBJ         += $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.f90=%_dev.o)))
+DEV_OBJ          += $(addprefix $(OBJ_DIR)/,$(addsuffix _dev.o, $(basename $(notdir $(F_SOURCE)))))
 DEV_DEPS         = $(DEV_OBJ:%.o=%.d)
 GT_OBJ           = $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_gt.o)))
-GT_OBJ          += $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.f90=%_gt.o)))
+GT_OBJ          += $(addprefix $(OBJ_DIR)/,$(addsuffix _gt.o, $(basename $(notdir $(F_SOURCE)))))
 GT_DEPS          = $(GT_OBJ:%.o=%.d)
 GT_OBJ_FPIC      = $(GT_OBJ:%.o=%_fPIC.o)
 
@@ -287,10 +293,11 @@ R_CUR_SWITCHES  ?=
 # If we are in a recursion
 ifdef R_IS_RECURSED
 
-R_ID            := $(R_CUR_COMPILER)_$(HOSTNAME)_$(R_CUR_SWITCHES)_$(R_CUR_OPTL)
+R_ID            := $(R_CUR_COLLECTION)_$(HOSTNAME)_$(R_CUR_SWITCHES)_$(R_CUR_OPTL)
 R_TARGET        := $(RESULTS_DIR)/$(R_ID)
 R_OBJ           := $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_$(R_ID).o)))
-R_OBJ           += $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.f90=%_$(R_ID).o)))
+# this may exclude source files with a dot in their name...
+R_OBJ           += $(addprefix $(OBJ_DIR)/,$(addsuffix _$(R_ID).o, $(basename $(notdir $(F_SOURCE)))))
 R_DEP           := $(R_OBJ:%.o=%.d)
 
 -include $(R_DEP)
@@ -314,10 +321,10 @@ $(R_TARGET): $(R_OBJ)
 	  $($(R_CUR_COMPILER)_REQUIRED) $(CC_REQUIRED) \
 	  $(R_OBJ) -o $@ \
 	  $(LD_REQUIRED)
-#if fortran, change cpp to fortran
+
 $(OBJ_DIR)/%_$(R_ID).o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 	$($($(R_CUR_COLLECTION)_CXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
-	  -c $($($(R_CUR_COLLECTION)_CXX)_REQUIRED) $(F_REQUIRED) \
+	  -c $($($(R_CUR_COLLECTION)_CXX)_REQUIRED) $(CC_REQUIRED) \
 	  $< -o $@ \
 	  $(DEPFLAGS) \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
@@ -326,9 +333,22 @@ $(OBJ_DIR)/%_$(R_ID).o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 	  -DFLIT_SWITCHES='"$($(R_CUR_SWITCHES))"' \
 	  -DFLIT_FILENAME='"$(R_ID)"'
 
+# FORTRAN copy of the previous cpp rule
 $(OBJ_DIR)/%_$(R_ID).o: %.f90 Makefile custom.mk | $(OBJ_DIR)
 	$($($(R_CUR_COLLECTION)_FXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
-	  -c $($($(R_CUR_COLLECTION)_FXX)_REQUIRED) $(CC_REQUIRED) \
+	  -c $($($(R_CUR_COLLECTION)_FXX)_REQUIRED) $(F_REQUIRED) \
+	  $< -o $@ \
+	  $(DEPFLAGS) \
+	  -DFLIT_HOST='"$(HOSTNAME)"' \
+	  -DFLIT_COMPILER='"$($($(R_CUR_COLLECTION)_FXX))"' \
+	  -DFLIT_OPTL='"$($(R_CUR_OPTL))"' \
+	  -DFLIT_SWITCHES='"$($(R_CUR_SWITCHES))"' \
+	  -DFLIT_FILENAME='"$(R_ID)"'
+
+# Fixed Form FORTRAN copy
+$(OBJ_DIR)/%_$(R_ID).o: %.F90 Makefile custom.mk | $(OBJ_DIR)
+	$($($(R_CUR_COLLECTION)_FXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
+	  -c $($($(R_CUR_COLLECTION)_FXX)_REQUIRED) $(F_FIX_REQUIRED) \
 	  $< -o $@ \
 	  $(DEPFLAGS) \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
@@ -500,6 +520,24 @@ $(OBJ_DIR)/%_dev.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 	  -DFLIT_SWITCHES='"$(DEV_SWITCHES)"' \
 	  -DFLIT_FILENAME='"$(notdir $(DEV_TARGET))"'
 
+# FORTRAN copy of the previous cpp rule
+$(OBJ_DIR)/%_dev.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
+	$($($(DEV_COLLECTION)_FXX)) $(DEV_OPTL) $(DEV_SWITCHES) $(F_REQUIRED) $(DEV_CFLAGS) $(DEPFLAGS) -c $< -o $@ \
+	  -DFLIT_HOST='"$(HOSTNAME)"' \
+	  -DFLIT_COMPILER='"$($($(DEV_COLLECTION)_FXX))"' \
+	  -DFLIT_OPTL='"$(DEV_OPTL)"' \
+	  -DFLIT_SWITCHES='"$(DEV_SWITCHES)"' \
+	  -DFLIT_FILENAME='"$(notdir $(DEV_TARGET))"'
+
+# Fixed Form FORTRAN copy
+$(OBJ_DIR)/%_dev.o: %.F90 Makefile custom.mk | $(OBJ_DIR)
+	$($($(DEV_COLLECTION)_FXX)) $(DEV_OPTL) $(DEV_SWITCHES) $(F_FIX_REQUIRED) $(DEV_CFLAGS) $(DEPFLAGS) -c $< -o $@ \
+	  -DFLIT_HOST='"$(HOSTNAME)"' \
+	  -DFLIT_COMPILER='"$($($(DEV_COLLECTION)_FXX))"' \
+	  -DFLIT_OPTL='"$(DEV_OPTL)"' \
+	  -DFLIT_SWITCHES='"$(DEV_SWITCHES)"' \
+	  -DFLIT_FILENAME='"$(notdir $(DEV_TARGET))"'
+
 # Ground truth compilation rules
 $(GT_OUT): $(GT_TARGET)
 	$(RUNWRAP) ./$(GT_TARGET) --output $(GT_OUT) --no-timing
@@ -515,10 +553,46 @@ $(OBJ_DIR)/%_gt.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 	  -DFLIT_SWITCHES='"$(GT_SWITCHES)"' \
 	  -DFLIT_FILENAME='"$(notdir $(GT_TARGET))"'
 
+# FORTRAN copy of the previous cpp rule
+$(OBJ_DIR)/%_gt.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
+	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_REQUIRED) $(DEPFLAGS) -c $< -o $@ \
+	  -DFLIT_HOST='"$(HOSTNAME)"' \
+	  -DFLIT_COMPILER='"$($($(GT_COLLECTION)_FXX))"' \
+	  -DFLIT_OPTL='"$(GT_OPTL)"' \
+	  -DFLIT_SWITCHES='"$(GT_SWITCHES)"' \
+	  -DFLIT_FILENAME='"$(notdir $(GT_TARGET))"'
+
+# Fixed Form FORTRAN copy
+$(OBJ_DIR)/%_gt.o: %.F90 Makefile custom.mk | $(OBJ_DIR)
+	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_FIX_REQUIRED) $(DEPFLAGS) -c $< -o $@ \
+	  -DFLIT_HOST='"$(HOSTNAME)"' \
+	  -DFLIT_COMPILER='"$($($(GT_COLLECTION)_FXX))"' \
+	  -DFLIT_OPTL='"$(GT_OPTL)"' \
+	  -DFLIT_SWITCHES='"$(GT_SWITCHES)"' \
+	  -DFLIT_FILENAME='"$(notdir $(GT_TARGET))"'
+
 $(OBJ_DIR)/%_gt_fPIC.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 	$(GT_CXX) -g $(GT_OPTL) $(GT_SWITCHES) $(CC_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$(GT_CXX)"' \
+	  -DFLIT_OPTL='"$(GT_OPTL)"' \
+	  -DFLIT_SWITCHES='"$(GT_SWITCHES)"' \
+	  -DFLIT_FILENAME='"$(notdir $(GT_TARGET))"'
+
+# FORTRAN copy of the previous cpp rule
+$(OBJ_DIR)/%_gt_fPIC.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
+	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
+	  -DFLIT_HOST='"$(HOSTNAME)"' \
+	  -DFLIT_COMPILER='"$($($(GT_COLLECTION)_FXX))"' \
+	  -DFLIT_OPTL='"$(GT_OPTL)"' \
+	  -DFLIT_SWITCHES='"$(GT_SWITCHES)"' \
+	  -DFLIT_FILENAME='"$(notdir $(GT_TARGET))"'
+
+# Fixed Form FORTRAN copy
+$(OBJ_DIR)/%_gt_fPIC.o: %.F90 Makefile custom.mk | $(OBJ_DIR)
+	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_FIX_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
+	  -DFLIT_HOST='"$(HOSTNAME)"' \
+	  -DFLIT_COMPILER='"$($($(GT_COLLECTION)_FXX))"' \
 	  -DFLIT_OPTL='"$(GT_OPTL)"' \
 	  -DFLIT_SWITCHES='"$(GT_SWITCHES)"' \
 	  -DFLIT_FILENAME='"$(notdir $(GT_TARGET))"'

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -114,13 +114,13 @@ FLIT_LIB_DIR    := {flit_lib_dir}
 FLIT_DATA_DIR   := {flit_data_dir}
 FLIT_SCRIPT_DIR := {flit_script_dir}
 
-DEV_COLLECTION  ?= {dev_compiler_collection}
+DEV_COLLECTION  ?= {dev_collection}
 DEV_CXX         ?= $($($(DEV_COLLECTION)_CXX))
 DEV_CXX_TYPE    ?= {dev_type}
 DEV_OPTL        ?= {dev_optl}
 DEV_SWITCHES    ?= {dev_switches}
 
-GT_COLLECTION   := {ground_truth_compiler_collection}
+GT_COLLECTION   := {ground_truth_collection}
 GT_CXX          := $($($(GT_COLLECTION)_CXX))
 GT_CXX_TYPE     := {ground_truth_type}
 GT_OPTL         := {ground_truth_optl}

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -91,9 +91,15 @@ UNAME_S         := {uname}
 
 # will be None if not specified in flit-config.toml
 {compiler_defs}
-CLANG_TYPE      := clang
-INTEL_TYPE      := intel
-GCC_TYPE        := gcc
+
+# Required flags, LD flags, and Types are kept track of
+#             on a per compiler basis
+
+{compiler_required_flags}
+
+{compiler_ld_flags}
+
+{compiler_types}
 
 # keep only the compilers that are not None and are in the path
 COMPILERS       := {compilers}
@@ -116,13 +122,13 @@ FLIT_SCRIPT_DIR := {flit_script_dir}
 
 DEV_COLLECTION  ?= {dev_collection}
 DEV_CXX         ?= $($($(DEV_COLLECTION)_CXX))
-DEV_CXX_TYPE    ?= {dev_type}
+DEV_CXX_TYPE    ?= $($($(DEV_COLLECTION)_CXX)_TYPE)
 DEV_OPTL        ?= {dev_optl}
 DEV_SWITCHES    ?= {dev_switches}
 
 GT_COLLECTION   := {ground_truth_collection}
 GT_CXX          := $($($(GT_COLLECTION)_CXX))
-GT_CXX_TYPE     := {ground_truth_type}
+GT_CXX_TYPE     := $($($(DEV_COLLECTION)_CXX)_TYPE)
 GT_OPTL         := {ground_truth_optl}
 GT_SWITCHES     := {ground_truth_switches}
 
@@ -300,6 +306,9 @@ R_OBJ           := $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%.cpp=%_$(R_ID).o))
 R_OBJ           += $(addprefix $(OBJ_DIR)/,$(addsuffix _$(R_ID).o, $(basename $(notdir $(F_SOURCE)))))
 R_DEP           := $(R_OBJ:%.o=%.d)
 
+R_CUR_CXX       := $($(R_CUR_COLLECTION)_CXX)
+R_CUR_FXX       := $($(R_CUR_COLLECTION)_FXX)
+
 -include $(R_DEP)
 
 .PHONY: rec
@@ -308,51 +317,51 @@ rec: $(R_TARGET)
 # clang's flag is -nopie
 # else if the current compiler is not GCC 4 or 5, then enable -no-pie
 # GCC 4 and 5 do not need -no-pie since that is the default
-ifeq ($($(R_CUR_COMPILER)_TYPE),clang)
+ifeq ($($(R_CUR_CXX)_TYPE),clang)
   LD_REQUIRED += -nopie
-else ifeq ($($(R_CUR_COMPILER)_TYPE), gcc)
-ifeq ($(call IS_VER_4_OR_5,$($(R_CUR_COMPILER))),0)
+else ifeq ($($(R_CUR_CXX)_TYPE), gcc)
+ifeq ($(call IS_VER_4_OR_5,$($(R_CUR_CXX))),0)
   LD_REQUIRED += -no-pie
 endif
 endif
 
 $(R_TARGET): $(R_OBJ)
-	$($($(R_CUR_COLLECTION)_CXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
-	  $($(R_CUR_COMPILER)_REQUIRED) $(CC_REQUIRED) \
+	$($(R_CUR_CXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
+	  $($(R_CUR_CXX)_REQUIRED) $(CC_REQUIRED) \
 	  $(R_OBJ) -o $@ \
-	  $(LD_REQUIRED)
+	  $(LD_REQUIRED) $($(R_CUR_CXX)_LD_REQUIRED)
 
 $(OBJ_DIR)/%_$(R_ID).o: %.cpp Makefile custom.mk | $(OBJ_DIR)
-	$($($(R_CUR_COLLECTION)_CXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
-	  -c $($($(R_CUR_COLLECTION)_CXX)_REQUIRED) $(CC_REQUIRED) \
+	$($(R_CUR_CXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
+	  -c $($(R_CUR_CXX)_REQUIRED) $(CC_REQUIRED) \
 	  $< -o $@ \
 	  $(DEPFLAGS) \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
-	  -DFLIT_COMPILER='"$($($(R_CUR_COLLECTION)_CXX))"' \
+	  -DFLIT_COMPILER='"$($(R_CUR_CXX))"' \
 	  -DFLIT_OPTL='"$($(R_CUR_OPTL))"' \
 	  -DFLIT_SWITCHES='"$($(R_CUR_SWITCHES))"' \
 	  -DFLIT_FILENAME='"$(R_ID)"'
 
 # FORTRAN copy of the previous cpp rule
 $(OBJ_DIR)/%_$(R_ID).o: %.f90 Makefile custom.mk | $(OBJ_DIR)
-	$($($(R_CUR_COLLECTION)_FXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
-	  -c $($($(R_CUR_COLLECTION)_FXX)_REQUIRED) $(F_REQUIRED) \
+	$($(R_CUR_FXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
+	  -c $($(R_CUR_FXX)_REQUIRED) $(F_REQUIRED) \
 	  $< -o $@ \
 	  $(DEPFLAGS) \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
-	  -DFLIT_COMPILER='"$($($(R_CUR_COLLECTION)_FXX))"' \
+	  -DFLIT_COMPILER='"$($(R_CUR_FXX))"' \
 	  -DFLIT_OPTL='"$($(R_CUR_OPTL))"' \
 	  -DFLIT_SWITCHES='"$($(R_CUR_SWITCHES))"' \
 	  -DFLIT_FILENAME='"$(R_ID)"'
 
 # Fixed Form FORTRAN copy
 $(OBJ_DIR)/%_$(R_ID).o: %.F90 Makefile custom.mk | $(OBJ_DIR)
-	$($($(R_CUR_COLLECTION)_FXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
-	  -c $($($(R_CUR_COLLECTION)_FXX)_REQUIRED) $(F_FIX_REQUIRED) \
+	$($(R_CUR_FXX)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
+	  -c $($(R_CUR_FXX)_REQUIRED) $(F_FIX_REQUIRED) \
 	  $< -o $@ \
 	  $(DEPFLAGS) \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
-	  -DFLIT_COMPILER='"$($($(R_CUR_COLLECTION)_FXX))"' \
+	  -DFLIT_COMPILER='"$($(R_CUR_FXX))"' \
 	  -DFLIT_OPTL='"$($(R_CUR_OPTL))"' \
 	  -DFLIT_SWITCHES='"$($(R_CUR_SWITCHES))"' \
 	  -DFLIT_FILENAME='"$(R_ID)"'
@@ -510,10 +519,12 @@ endif # ifeq ($(UNAME_S),Darwin): meaning, we are on a mac
 # Dev compilation rules first (easier to understand)
 $(DEV_TARGET): $(DEV_OBJ) Makefile custom.mk
 	$(DEV_CXX) $(CC_REQUIRED) $(DEV_CFLAGS) \
-	  -o $@ $(DEV_OBJ) $(LD_REQUIRED) $(DEV_LDFLAGS)
+	  -o $@ $(DEV_OBJ) $(LD_REQUIRED) $(DEV_LDFLAGS) \
+          $($($(DEV_COLLECTION)_CXX)_LD_REQUIRED)
 
 $(OBJ_DIR)/%_dev.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
-	$(DEV_CXX) $(DEV_OPTL) $(DEV_SWITCHES) $(CC_REQUIRED) $(DEV_CFLAGS) $(DEPFLAGS) -c $< -o $@ \
+	$(DEV_CXX) $(DEV_OPTL) $(DEV_SWITCHES) $(CC_REQUIRED) \
+        $($($(DEV_COLLECTION)_CXX)_REQUIRED) $(DEV_CFLAGS) $(DEPFLAGS) -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$(DEV_CXX)"' \
 	  -DFLIT_OPTL='"$(DEV_OPTL)"' \
@@ -522,7 +533,8 @@ $(OBJ_DIR)/%_dev.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 
 # FORTRAN copy of the previous cpp rule
 $(OBJ_DIR)/%_dev.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
-	$($($(DEV_COLLECTION)_FXX)) $(DEV_OPTL) $(DEV_SWITCHES) $(F_REQUIRED) $(DEV_CFLAGS) $(DEPFLAGS) -c $< -o $@ \
+	$($($(DEV_COLLECTION)_FXX)) $(DEV_OPTL) $(DEV_SWITCHES) $(F_REQUIRED) \
+        $($($(DEV_COLLECTION)_FXX)_REQUIRED) $(DEV_CFLAGS) $(DEPFLAGS) -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$($($(DEV_COLLECTION)_FXX))"' \
 	  -DFLIT_OPTL='"$(DEV_OPTL)"' \
@@ -531,7 +543,8 @@ $(OBJ_DIR)/%_dev.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
 
 # Fixed Form FORTRAN copy
 $(OBJ_DIR)/%_dev.o: %.F90 Makefile custom.mk | $(OBJ_DIR)
-	$($($(DEV_COLLECTION)_FXX)) $(DEV_OPTL) $(DEV_SWITCHES) $(F_FIX_REQUIRED) $(DEV_CFLAGS) $(DEPFLAGS) -c $< -o $@ \
+	$($($(DEV_COLLECTION)_FXX)) $(DEV_OPTL) $(DEV_SWITCHES) $(F_FIX_REQUIRED) \
+        $($($(DEV_COLLECTION)_FXX)_REQUIRED) $(DEV_CFLAGS) $(DEPFLAGS) -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$($($(DEV_COLLECTION)_FXX))"' \
 	  -DFLIT_OPTL='"$(DEV_OPTL)"' \
@@ -543,10 +556,12 @@ $(GT_OUT): $(GT_TARGET)
 	$(RUNWRAP) ./$(GT_TARGET) --output $(GT_OUT) --no-timing
 
 $(GT_TARGET): $(GT_OBJ) Makefile custom.mk
-	$(GT_CXX) $(CC_REQUIRED) -o $@ $(GT_OBJ) $(LD_REQUIRED) $(GT_LDFLAGS)
+	$(GT_CXX) $(CC_REQUIRED) -o $@ $(GT_OBJ) $(LD_REQUIRED) $(GT_LDFLAGS) \
+        $($($(DEV_COLLECTION)_CXX)_LD_REQUIRED) 
 
 $(OBJ_DIR)/%_gt.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
-	$(GT_CXX) -g $(GT_OPTL) $(GT_SWITCHES) $(CC_REQUIRED) $(DEPFLAGS) -c $< -o $@ \
+	$(GT_CXX) -g $(GT_OPTL) $(GT_SWITCHES) $(CC_REQUIRED) \
+        $($($(GT_COLLECTION)_CXX)_REQUIRED) $(DEPFLAGS) -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$(GT_CXX)"' \
 	  -DFLIT_OPTL='"$(GT_OPTL)"' \
@@ -555,7 +570,8 @@ $(OBJ_DIR)/%_gt.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 
 # FORTRAN copy of the previous cpp rule
 $(OBJ_DIR)/%_gt.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
-	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_REQUIRED) $(DEPFLAGS) -c $< -o $@ \
+	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_REQUIRED) \
+        $($($(GT_COLLECTION)_FXX)_REQUIRED) $(DEPFLAGS) -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$($($(GT_COLLECTION)_FXX))"' \
 	  -DFLIT_OPTL='"$(GT_OPTL)"' \
@@ -564,7 +580,8 @@ $(OBJ_DIR)/%_gt.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
 
 # Fixed Form FORTRAN copy
 $(OBJ_DIR)/%_gt.o: %.F90 Makefile custom.mk | $(OBJ_DIR)
-	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_FIX_REQUIRED) $(DEPFLAGS) -c $< -o $@ \
+	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_FIX_REQUIRED) \
+        $($($(GT_COLLECTION)_FXX)_REQUIRED) $(DEPFLAGS) -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$($($(GT_COLLECTION)_FXX))"' \
 	  -DFLIT_OPTL='"$(GT_OPTL)"' \
@@ -572,7 +589,8 @@ $(OBJ_DIR)/%_gt.o: %.F90 Makefile custom.mk | $(OBJ_DIR)
 	  -DFLIT_FILENAME='"$(notdir $(GT_TARGET))"'
 
 $(OBJ_DIR)/%_gt_fPIC.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
-	$(GT_CXX) -g $(GT_OPTL) $(GT_SWITCHES) $(CC_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
+	$(GT_CXX) -g $(GT_OPTL) $(GT_SWITCHES) $(CC_REQUIRED) \
+        $($($(GT_COLLECTION)_CXX)_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$(GT_CXX)"' \
 	  -DFLIT_OPTL='"$(GT_OPTL)"' \
@@ -581,7 +599,8 @@ $(OBJ_DIR)/%_gt_fPIC.o: %.cpp Makefile custom.mk | $(OBJ_DIR)
 
 # FORTRAN copy of the previous cpp rule
 $(OBJ_DIR)/%_gt_fPIC.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
-	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
+	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_REQUIRED) \
+        $($($(GT_COLLECTION)_FXX)_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$($($(GT_COLLECTION)_FXX))"' \
 	  -DFLIT_OPTL='"$(GT_OPTL)"' \
@@ -590,7 +609,8 @@ $(OBJ_DIR)/%_gt_fPIC.o: %.f90 Makefile custom.mk | $(OBJ_DIR)
 
 # Fixed Form FORTRAN copy
 $(OBJ_DIR)/%_gt_fPIC.o: %.F90 Makefile custom.mk | $(OBJ_DIR)
-	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_FIX_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
+	$($($(GT_COLLECTION)_FXX)) -g $(GT_OPTL) $(GT_SWITCHES) $(F_FIX_REQUIRED) \
+        $($($(GT_COLLECTION)_FXX)_REQUIRED) $(DEPFLAGS) -fPIC -c $< -o $@ \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$($($(GT_COLLECTION)_FXX))"' \
 	  -DFLIT_OPTL='"$(GT_OPTL)"' \

--- a/scripts/flitcli/config/flit-default.toml.in
+++ b/scripts/flitcli/config/flit-default.toml.in
@@ -134,7 +134,7 @@ mpirun_args = ''
 # compiler_name must be found in the [[compiler]] list under the name attribute
 # The optimization level and switches need not match those found in the
 # associated [[compiler]]
-compiler_name = 'g++'
+compiler_name = 'gcc'
 optimization_level = '-O2'
 switches = '-funsafe-math-optimizations'
 
@@ -145,7 +145,7 @@ switches = '-funsafe-math-optimizations'
 # compiler_name must be found in the [[compiler]] list under the name attribute
 # The optimization level and switches need not match those found in the
 # associated [[compiler]]
-compiler_name = 'g++'
+compiler_name = 'gcc'
 optimization_level = '-O0'
 switches = ''
 
@@ -322,5 +322,10 @@ switches_list = [
 ]
 
 [[compiler_collection]]
-cpp_name = 'g++'
-fortran_name = 'gfortran'
+name = 'gcc'
+langs = [
+  'cpp',
+  'fortran'
+]
+cpp = 'g++'
+fortran = 'gfortran'

--- a/scripts/flitcli/config/flit-default.toml.in
+++ b/scripts/flitcli/config/flit-default.toml.in
@@ -166,6 +166,44 @@ switches = ''
 binary = 'g++'
 name = 'g++'
 type = 'gcc'
+lang = 'c++'
+# search space of optimization levels
+optimization_levels = [
+  '-O0',
+  '-O1',
+  '-O2',
+  '-O3',
+]
+# search space of compiler switches.
+# Note: in some versions of python-toml, there is a parsing bug when a list
+#       has an empty string in the middle.  So simply put it at the end without
+#       a comma.  This has been fixed in the latest version of python-toml.
+# Note: gcc disables -fassociative-math @ O0
+switches_list = [
+  '-fassociative-math',
+  '-fcx-fortran-rules',
+  '-fcx-limited-range',
+  '-fexcess-precision=fast',
+  '-ffinite-math-only',
+  '-ffloat-store',
+  '-ffp-contract=on',
+  '-fmerge-all-constants',
+  '-fno-trapping-math',
+  '-freciprocal-math',
+  '-frounding-math',
+  '-fsignaling-nans',
+  '-funsafe-math-optimizations',
+  '-mavx',
+  '-mavx2 -mfma',
+  '-mfpmath=sse -mtune=native',
+  ''
+]
+
+[[compiler]]
+binary = 'gfortran'
+name = 'gfortran'
+type = 'gcc'
+lang = 'fortran'
 # search space of optimization levels
 optimization_levels = [
   '-O0',
@@ -202,6 +240,7 @@ switches_list = [
 binary = 'clang++'
 name = 'clang++'
 type = 'clang'
+lang = 'c++'
 # search space of optimization levels
 optimization_levels = [
   '-O0',
@@ -240,6 +279,7 @@ switches_list = [
 binary = 'icpc'
 name = 'icpc'
 type = 'intel'
+lang = 'c++'
 # search space of optimization levels
 optimization_levels = [
   '-O0',
@@ -280,3 +320,7 @@ switches_list = [
   '-prec-div',
   ''
 ]
+
+[[compiler_collection]]
+cpp_name = 'g++'
+fortran_name = 'gfortran'

--- a/scripts/flitcli/config/flit-default.toml.in
+++ b/scripts/flitcli/config/flit-default.toml.in
@@ -167,6 +167,8 @@ binary = 'g++'
 name = 'g++'
 type = 'gcc'
 lang = 'c++'
+required_flags = ''
+ld_flags = ''
 # search space of optimization levels
 optimization_levels = [
   '-O0',
@@ -204,6 +206,8 @@ binary = 'gfortran'
 name = 'gfortran'
 type = 'gcc'
 lang = 'fortran'
+required_flags = ''
+ld_flags = ''
 # search space of optimization levels
 optimization_levels = [
   '-O0',
@@ -241,6 +245,8 @@ binary = 'clang++'
 name = 'clang++'
 type = 'clang'
 lang = 'c++'
+required_flags = ''
+ld_flags = ''
 # search space of optimization levels
 optimization_levels = [
   '-O0',
@@ -280,6 +286,8 @@ binary = 'icpc'
 name = 'icpc'
 type = 'intel'
 lang = 'c++'
+required_flags = ''
+ld_flags = ''
 # search space of optimization levels
 optimization_levels = [
   '-O0',

--- a/scripts/flitcli/flit_update.py
+++ b/scripts/flitcli/flit_update.py
@@ -353,7 +353,7 @@ def main(arguments, prog=sys.argv[0]):
             collection[name].upper() for name in collection['langs']} 
             for collection in collections]
 
-    cxx_type = lambda collection : [x for x in projconf['compilers']
+    cxx_type = lambda collection : [x for x in projconf['compiler']
                                    if x['name'] == collection['cpp']][0]['type']
 
     replacements = {
@@ -364,7 +364,7 @@ def main(arguments, prog=sys.argv[0]):
         'dev_optl': dev_build['optimization_level'],
         'dev_switches': dev_build['switches'],
         'ground_truth_collection': matching_gt_collections[0]['name'].upper(),
-        'ground_truth_type': cxx_type(matching_dev_collections[0]),
+        'ground_truth_type': cxx_type(matching_gt_collections[0]),
         'ground_truth_optl': ground_truth['optimization_level'],
         'ground_truth_switches': ground_truth['switches'],
         'flit_include_dir': conf.include_dir,

--- a/scripts/flitcli/flit_update.py
+++ b/scripts/flitcli/flit_update.py
@@ -138,7 +138,9 @@ def load_projconf(directory):
             'needs [[compiler]] section'
 
         default_type_map = {c['type']: c for c in defaults['compiler']}
-        type_map = {} # type -> compiler
+        # types are not longer unique with collections. However,
+        #  we should never have a compiler of the same name and type
+        type_map = {} # type##name -> compiler
         name_map = {} # name -> compiler
         for compiler in projconf['compiler']:
 
@@ -154,10 +156,11 @@ def load_projconf(directory):
                 .format(compiler['type'])
 
             # check that we only have one of each type specified
-            assert compiler['type'] not in type_map, \
+            compiler_key = compiler['type'] + '##' + compiler['name']
+            assert compiler_key not in type_map, \
                 'flit-config.toml: cannot have multiple compilers of the ' \
-                'same type ({0})'.format(compiler['type'])
-            type_map[compiler['type']] = compiler
+                'same type and name ({0})'.format(compiler_key)
+            type_map[compiler_key] = compiler
 
             # check that we only have one of each name specified
             assert compiler['name'] not in name_map, \
@@ -211,6 +214,21 @@ def flag_name(flag):
         'Error: cannot handle flag that starts with a number'
     assert len(name) > 0, 'Error: cannot handle flag only made of dashes'
     return name
+
+def lang_name(lang):
+    ''' 
+    Returns an appropriate Makefile name for a compiler of the
+    given language
+    '''
+
+    if lang == 'cpp':
+        return "CXX"
+    if lang == "c":
+        return "CC"
+    if lang == "fortran":
+        return "FXX"
+    
+    raise Exception("Unsupported Language: " + lang)
 
 def gen_assignments(flag_map):
     '''
@@ -301,19 +319,25 @@ def main(arguments, prog=sys.argv[0]):
         print('Creating {0}'.format(makefile))
 
     dev_build = projconf['dev_build']
-    matching_dev_compilers = [x for x in projconf['compiler']
+    matching_dev_collections = [x for x in projconf['compiler_collection']
                               if x['name'] == dev_build['compiler_name']]
-    assert len(matching_dev_compilers) > 0, \
-            'Compiler name {0} not found'.format(dev_build['compiler_name'])
+    assert len(matching_dev_collections) > 0, \
+            'Compiler collection name {0} not found'.format(dev_build['compiler_name'])
+    assert len(matching_dev_collections) < 2, \
+            'Multiple compilers with name {0} found' \
+            .format(dev_build['compiler_name'])
 
     ground_truth = projconf['ground_truth']
-    matching_gt_compilers = [x for x in projconf['compiler']
+    matching_gt_collections = [x for x in projconf['compiler_collection']
                              if x['name'] == ground_truth['compiler_name']]
-    assert len(matching_gt_compilers) > 0, \
-            'Compiler name {0} not found'.format(ground_truth['compiler_name'])
+    assert len(matching_gt_collections) > 0, \
+            'Compiler collection name {0} not found'.format(ground_truth['compiler_name'])
+    assert len(matching_gt_collections) < 2, \
+            'Multiple compilers with name {0} found' \
+            .format(ground_truth['compiler_name'])
 
-    base_compilers = {x.upper(): None for x in _supported_compiler_types}
-    base_compilers.update({compiler['type'].upper(): compiler['binary']
+    base_compilers = {}#{x.upper(): None for x in _supported_compiler_types}
+    base_compilers.update({compiler['name'].upper(): compiler['binary']
                            for compiler in projconf['compiler']})
 
     test_run_args = ''
@@ -324,16 +348,23 @@ def main(arguments, prog=sys.argv[0]):
             '--timing-loops', str(projconf['run']['timing_loops']),
             '--timing-repeats', str(projconf['run']['timing_repeats']),
             ])
+    collections = projconf['compiler_collection']
+    collections_def_map = [{collection['name'].upper() + '_' + lang_name(name): \
+            collection[name].upper() for name in collection['langs']} 
+            for collection in collections]
+
+    cxx_type = lambda collection : [x for x in projconf['compilers']
+                                   if x['name'] == collection['cpp']][0]['type']
 
     replacements = {
         'uname': os.uname().sysname,
         'hostname': os.uname().nodename,
-        'dev_compiler': matching_dev_compilers[0]['binary'],
-        'dev_type': matching_dev_compilers[0]['type'],
+        'dev_collection': matching_dev_collections[0]['name'].upper(),
+        'dev_type': cxx_type(matching_dev_collections[0]),
         'dev_optl': dev_build['optimization_level'],
         'dev_switches': dev_build['switches'],
-        'ground_truth_compiler': matching_gt_compilers[0]['binary'],
-        'ground_truth_type': matching_gt_compilers[0]['type'],
+        'ground_truth_collection': matching_gt_collections[0]['name'].upper(),
+        'ground_truth_type': cxx_type(matching_dev_collections[0]),
         'ground_truth_optl': ground_truth['optimization_level'],
         'ground_truth_switches': ground_truth['switches'],
         'flit_include_dir': conf.include_dir,
@@ -344,9 +375,13 @@ def main(arguments, prog=sys.argv[0]):
         'test_run_args': test_run_args,
         'enable_mpi': 'yes' if projconf['run']['enable_mpi'] else 'no',
         'mpirun_args': projconf['run']['mpirun_args'],
+        'collections': ' '.join(collection['name'].upper() 
+            for collection in projconf['compiler_collection']),
+        'collection_defs': '\n\n'.join([gen_assignments(collection) 
+            for collection in collections_def_map]),
         'compiler_defs': gen_assignments({
             key: val for key, val in base_compilers.items()}),
-        'compilers': ' '.join([compiler['type'].upper()
+        'compilers': ' '.join([compiler['name'].upper()
                                for compiler in projconf['compiler']]),
         'opcodes_definitions': gen_assignments({
             flag_name(x): x
@@ -358,12 +393,12 @@ def main(arguments, prog=sys.argv[0]):
             for x in compiler['switches_list']}),
         'compiler_opcodes': '\n\n'.join([
             gen_multi_assignment(
-                'OPCODES_' + compiler['type'].upper(),
+                'OPCODES_' + compiler['name'].upper(),
                 [flag_name(x) for x in compiler['optimization_levels']])
             for compiler in projconf['compiler']]),
         'compiler_switches': '\n\n'.join([
             gen_multi_assignment(
-                'SWITCHES_' + compiler['type'].upper(),
+                'SWITCHES_' + compiler['name'].upper(),
                 [flag_name(x) for x in compiler['switches_list']])
             for compiler in projconf['compiler']]),
         }


### PR DESCRIPTION
Fixes #93 

Also Fixes #125 

**Description:**
Describe what you changed and why.

- Added compiler collections which allow for fortran support
- Added per-compiler attributes which allow for per-compiler flags specified in the .toml file

**Documentation:**
None yet
**Tests:**
none yet