### PR TITLE
Issue222 mpich support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,13 +101,15 @@ matrix:
             - libopenmpi-dev
             - openmpi-bin
     # Job 2: MPICH
-    #- env: mpi_type=mpich
-    #  addons:
-    #    apt:
-    #      packages:
-    #        - *native_deps
-    #        - libmpich-dev
-    #        - mpich
+    - env:
+      - mpi_type=mpich
+      - extra_pip=
+      addons:
+        apt:
+          packages:
+            - *native_deps
+            - libmpich-dev
+            - mpich
     # Job 3: No MPI
     - env:
       - mpi_type=none

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -135,7 +135,7 @@ ifeq ($(IS_OPENMPI),true)
 else  # IS_OPENMPI == false
   CC_REQUIRED   += $(shell mpic++ -compile_info 2>/dev/null | \
                            cut --delimiter ' ' --field 2-)
-  LD_REQUIRED   += $(shell mpic++ -link | cut --delimiter ' ' --field 2-)
+  LD_REQUIRED   += $(shell mpic++ -link_info | cut --delimiter ' ' --field 2-)
 endif # IS_OPENMPI == true
 endif # ENABLE_MPI == yes
 

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -128,9 +128,16 @@ RUNWRAP          = $(RUN_WRAPPER)
 ifeq ($(ENABLE_MPI),yes) # If we are using MPI
   RUNWRAP       += mpirun $(MPIRUN_ARGS)
   CC_REQUIRED   += -DFLIT_USE_MPI
-  CC_REQUIRED   += $(shell mpic++ --showme:compile)
-  LD_REQUIRED   += $(shell mpic++ --showme:link)
-endif
+  IS_OPENMPI    := $(shell mpic++ --showme:compile >/dev/null 2>&1 && echo true)
+ifeq ($(IS_OPENMPI),true)
+  CC_REQUIRED   += $(shell mpic++ --showme:compile 2>/dev/null)
+  LD_REQUIRED   += $(shell mpic++ --showme:link 2>/dev/null)
+else  # IS_OPENMPI == false
+  CC_REQUIRED   += $(shell mpic++ -compile_info 2>/dev/null | \
+                           cut --delimiter ' ' --field 2-)
+  LD_REQUIRED   += $(shell mpic++ -link | cut --delimiter ' ' --field 2-)
+endif # IS_OPENMPI == true
+endif # ENABLE_MPI == yes
 
 OBJ_DIR         := obj
 

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -133,6 +133,12 @@ OpenMPI is installed with
 sudo apt install openmpi-bin libopenmpi-dev
 ```
 
+Or you can alternatively use MPICH
+
+```bash
+sudo apt install mpich
+```
+
 ## FLiT Setup
 
 You will need FLiT available and compiled.  It can be optionally installed.


### PR DESCRIPTION
Fixes #222

**Description:**
Add support for MPICH within `Makefile.in`

**Documentation:**
In the installation section, I described how to optionally install MPICH as an alternative to OpenMPI.  This implies that we support both OpenMPI and MPICH.  Say something if you think more documentation is necessary.

**Tests:**
In TravisCI, I enabled running the tests with MPICH, so this will now be tested for every push.