### PR TITLE
Makefile.in: have recursive make happen with dry run

### DIFF
--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -306,6 +306,9 @@ R_CUR_COMPILER  ?=
 R_CUR_OPTL      ?=
 R_CUR_SWITCHES  ?=
 
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)
+
 # If we are in a recursion
 ifdef R_IS_RECURSED
 
@@ -369,8 +372,6 @@ ifeq ($(call IS_VER_4_OR_5,$(GT_CXX)),0)
 endif
 endif
 
-$(OBJ_DIR):
-	mkdir -p $(OBJ_DIR)
 $(RESULTS_DIR):
 	mkdir -p $(RESULTS_DIR)
 
@@ -396,7 +397,7 @@ TARGETS     += $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
 # rebuilt, so does each recursive target.
 
 $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2): $$(GT_TARGET) | $$(OBJ_DIR) $$(RESULTS_DIR)
-	-$$(MAKE) rec \
+	-+$$(MAKE) rec \
 	  R_IS_RECURSED=True \
 	  R_CUR_COMPILER=$(strip $1) \
 	  R_CUR_OPTL=$(strip $2) \


### PR DESCRIPTION
Fixes #267

**Description:**
Simply allowed the recursive Makefile to recurse even when called with `--dry-run`.  Done by adding a "+" character before the recursive call.

Also moved the creation of the `$(OBJ_DIR)` to before the `#if` so that we do not get errors in the recursive dry run call to make.

**Documentation:**
None needed.  This is more for debugging and testing than actual usage.

**Tests:**
None.  Just that existing tests continue to work.