### PR TITLE
Issue269 make clean dirs

### DIFF
--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -440,19 +440,15 @@ runbuild: $(TARGETS) groundtruth
 
 .PHONY: clean
 clean:
-	@# Here we do it this way because we were running into the error of too many
-	@# arguments given to rm.
-	$(foreach obj,$(OBJ_CLEAN),rm -f $(obj);)
-	$(foreach obj,$(DEP_CLEAN),rm -f $(obj);)
-	-rmdir $(OBJ_DIR)
+	rm -rf $(OBJ_DIR)
 
 .PHONY: veryclean distclean
 veryclean: distclean
 distclean: clean
 	rm -f $(DEV_TARGET)
-	rm -f $(TARGET_OUTS)
-	rm -f $(TARGET_RESULTS)
-	rm -f $(addsuffix *.dat,$(TARGET_OUTS))
+	find $(RESULTS_DIR) -name \*-out -delete
+	find $(RESULTS_DIR) -name \*-out\*.dat -delete
+	find $(RESULTS_DIR) -name \*-out-comparison.csv -delete
 	rm -f $(TARGETS)
 	rm -f $(GT_TARGET)
 	rm -f $(GT_OUT)

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -313,6 +313,9 @@ REC_DIRS        := $(foreach c, $(COMPILERS),\
                          $(OBJ_DIR)/$c_$(HOSTNAME)_$s_$o)))
 ALL_DIRS        += $(REC_DIRS)
 
+RUNBUILD_DIR := bin
+ALL_DIRS     += $(RUNBUILD_DIR)
+
 # will be set internally when doing recursive calls.  Get set to variable names
 # containing the information (e.g. R_CUR_COMPILER=CLANG)
 R_CUR_COMPILER  ?=
@@ -329,7 +332,7 @@ $(ALL_DIRS):
 ifdef R_IS_RECURSED
 
 R_ID            := $(R_CUR_COMPILER)_$(HOSTNAME)_$(R_CUR_SWITCHES)_$(R_CUR_OPTL)
-R_TARGET        := $(RESULTS_DIR)/$(R_ID)
+R_TARGET        := $(RUNBUILD_DIR)/$(R_ID)
 R_OBJ_DIR       := $(OBJ_DIR)/$(R_ID)
 R_OBJ           := $(addprefix $(R_OBJ_DIR)/,$(notdir $(SOURCE:%=%.o)))
 R_DEP           := $(R_OBJ:%.o=%.d)
@@ -350,7 +353,7 @@ ifeq ($(call IS_VER_4_OR_5,$($(R_CUR_COMPILER))),0)
 endif
 endif
 
-$(R_TARGET): $(R_OBJ)
+$(R_TARGET): $(R_OBJ) | $(RUNBUILD_DIR)
 	$($(R_CUR_COMPILER)) $($(R_CUR_OPTL)) $($(R_CUR_SWITCHES)) \
 	  $($(R_CUR_COMPILER)_REQUIRED) $(CC_REQUIRED) \
 	  $(R_OBJ) -o $@ \
@@ -395,13 +398,13 @@ endif
 
 # Set these as empty "simply-expanded variables".  This affects the "+=" operator.
 # see https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_6.html
-TARGET_OUTS :=
+TARGET_OUTS  :=
 
 # @param 1: compiler variable name (e.g. CLANG)
 # @param 2: optimization level variable name (e.g. O2)
 # @param 3: switches variable name (e.g. USE_FAST_MATH)
 define RECURSION_RULE
-TARGETS     += $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
+TARGETS     += $$(RUNBUILD_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
 
 # TODO: use the variable $$(MAKECMDGOALS) to get the original make target
 # TODO- or see if it is even necessary
@@ -410,13 +413,13 @@ TARGETS     += $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
 # depends on that target, but we know that when $$(GT_TARGET) needs to be
 # rebuilt, so does each recursive target.
 
-$$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2): $$(GT_TARGET) | $$(OBJ_DIR) $$(RESULTS_DIR)
-	-+$$(MAKE) rec --no-print-directory \
+$$(RUNBUILD_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2): $$(GT_TARGET) | $$(OBJ_DIR) $$(RUNBUILD_DIR)
+	-+@$$(MAKE) rec --no-print-directory \
 	  R_IS_RECURSED=True \
 	  R_CUR_COMPILER=$(strip $1) \
 	  R_CUR_OPTL=$(strip $2) \
 	  R_CUR_SWITCHES=$(strip $3)
-	-test -f $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
+	-test -f $$(RUNBUILD_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
 
 endef
 
@@ -424,10 +427,10 @@ $(foreach c, $(COMPILERS),                 \
   $(foreach s, $(SWITCHES_$(strip $c)),    \
     $(foreach o, $(OPCODES_$(strip $c)),               \
       $(eval $(call RECURSION_RULE, $c, $o, $s)))))
-TARGET_OUTS     := $(TARGETS:%=%-out)
+TARGET_OUTS     := $(addprefix $(RESULTS_DIR)/,$(notdir $(TARGETS:%=%-out)))
 TARGET_RESULTS  := $(TARGET_OUTS:%=%-comparison.csv)
 
-%-out: %
+$(RESULTS_DIR)/%-out: $(RUNBUILD_DIR)/% | $(RESULTS_DIR)
 	$(RUNWRAP) ./$< $(TEST_RUN_ARGS) --output $@ || touch $@
 
 # specify how to get comparison
@@ -459,17 +462,12 @@ clean:
 .PHONY: veryclean distclean
 veryclean: distclean
 distclean: clean
+	rm -rf $(RESULTS_DIR)
+	rm -rf $(RUNBUILD_DIR)
 	rm -f $(DEV_TARGET)
-	if [ -d "$(RESULTS_DIR)" ]; then \
-	  find "$(RESULTS_DIR)" -name \*-out -delete; \
-	  find "$(RESULTS_DIR)" -name \*-out\*.dat -delete; \
-	  find "$(RESULTS_DIR)" -name \*-out-comparison.csv -delete; \
-	fi
-	rm -f $(TARGETS)
 	rm -f $(GT_TARGET)
 	rm -f $(GT_OUT)
 	rm -f $(addsuffix *.dat,$(GT_OUT))
-	-rmdir $(RESULTS_DIR)
 
 Makefile: flit-config.toml
 Makefile: $(FLIT_DATA_DIR)/Makefile.in

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -140,6 +140,7 @@ endif # IS_OPENMPI == true
 endif # ENABLE_MPI == yes
 
 OBJ_DIR         := obj
+ALL_DIRS        := $(OBJ_DIR)
 
 CC_REQUIRED     += $(FFLAGS)
 # This flag specifies NOT to build position-independent executables
@@ -211,6 +212,7 @@ help:
 	@echo
 	@echo '  help        Show this help and exit (default target)'
 	@echo '  dev         Only run the devel compilation to test things out'
+	@echo '  dirs        Make only the directories, no files'
 	@echo '  groundtruth Compile the ground-truth version'
 	@echo '  gt          Same as groundtruth'
 	@echo '  runbuild    Build all executables needed for the run target'
@@ -231,15 +233,20 @@ SOURCE          := $(sort $(SOURCE))
 # We are done adding to VPATH, so consolidate it for speed (removing duplicates)
 VPATH           := $(sort $(VPATH))
 
-DEV_OBJ          = $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%=%_dev.o)))
-DEV_DEPS         = $(DEV_OBJ:%.o=%.d)
-GT_OBJ           = $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%=%_gt.o)))
-GT_DEPS          = $(GT_OBJ:%.o=%.d)
-GT_OBJ_FPIC      = $(GT_OBJ:%.o=%_fPIC.o)
+DEV_OBJ_DIR     := $(OBJ_DIR)/dev
+ALL_DIRS        += $(DEV_OBJ_DIR)
+DEV_OBJ         := $(addprefix $(DEV_OBJ_DIR)/,$(notdir $(SOURCE:%=%.o)))
+DEV_DEPS        := $(DEV_OBJ:%.o=%.d)
+GT_OBJ_DIR      := $(OBJ_DIR)/gt
+ALL_DIRS        += $(GT_OBJ_DIR)
+GT_OBJ          := $(addprefix $(GT_OBJ_DIR)/,$(notdir $(SOURCE:%=%.o)))
+GT_DEPS         := $(GT_OBJ:%.o=%.d)
+GT_OBJ_FPIC     := $(GT_OBJ:%.o=%_fPIC.o)
 
 HOSTNAME        := {hostname}
 
 RESULTS_DIR     := results
+ALL_DIRS        += $(RESULTS_DIR)
 
 # on systems with non-standard gcc installations (such as module), clang may
 # be unable to determine the correct gcc toolchain
@@ -291,7 +298,7 @@ endif
 # @param 6: target filename
 # @param 7: extra compiler flags
 define COMPILE_RULE
-$2: $1 Makefile custom.mk | $(OBJ_DIR)
+$2: $1 Makefile custom.mk | $(patsubst %/,%,$(dir $2))
 	$3 $4 $5 -c $7 $(CC_REQUIRED) $(DEPFLAGS) $(2:%.o=%.d) $1 -o $2 \
 	  -DFLIT_HOST='"$(HOSTNAME)"' \
 	  -DFLIT_COMPILER='"$(strip $3)"' \
@@ -300,21 +307,31 @@ $2: $1 Makefile custom.mk | $(OBJ_DIR)
 	  -DFLIT_FILENAME='"$(notdir $(strip $6))"'
 endef
 
+REC_DIRS        := $(foreach c, $(COMPILERS),\
+                     $(foreach s, $(SWITCHES_$(strip $c)),\
+                       $(foreach o, $(OPCODES_$(strip $c)),\
+                         $(OBJ_DIR)/$c_$(HOSTNAME)_$s_$o)))
+ALL_DIRS        += $(REC_DIRS)
+
 # will be set internally when doing recursive calls.  Get set to variable names
 # containing the information (e.g. R_CUR_COMPILER=CLANG)
 R_CUR_COMPILER  ?=
 R_CUR_OPTL      ?=
 R_CUR_SWITCHES  ?=
 
-$(OBJ_DIR):
-	mkdir -p $(OBJ_DIR)
+.PHONY: dirs
+dirs: $(ALL_DIRS)
+
+$(ALL_DIRS):
+	mkdir -p $@
 
 # If we are in a recursion
 ifdef R_IS_RECURSED
 
 R_ID            := $(R_CUR_COMPILER)_$(HOSTNAME)_$(R_CUR_SWITCHES)_$(R_CUR_OPTL)
 R_TARGET        := $(RESULTS_DIR)/$(R_ID)
-R_OBJ           := $(addprefix $(OBJ_DIR)/,$(notdir $(SOURCE:%=%_$(R_ID).o)))
+R_OBJ_DIR       := $(OBJ_DIR)/$(R_ID)
+R_OBJ           := $(addprefix $(R_OBJ_DIR)/,$(notdir $(SOURCE:%=%.o)))
 R_DEP           := $(R_OBJ:%.o=%.d)
 
 -include $(R_DEP)
@@ -342,7 +359,7 @@ $(R_TARGET): $(R_OBJ)
 $(foreach s,$(SOURCE), \
   $(eval $(call COMPILE_RULE,\
     $s,\
-    $(OBJ_DIR)/$(notdir $s)_$(R_ID).o,\
+    $(R_OBJ_DIR)/$(notdir $s).o,\
     $($(R_CUR_COMPILER)),\
     $($(R_CUR_OPTL)),\
     $($(R_CUR_SWITCHES)),\
@@ -372,9 +389,6 @@ ifeq ($(call IS_VER_4_OR_5,$(GT_CXX)),0)
 endif
 endif
 
-$(RESULTS_DIR):
-	mkdir -p $(RESULTS_DIR)
-
 #
 # Define the recursion rules
 #
@@ -397,7 +411,7 @@ TARGETS     += $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2)
 # rebuilt, so does each recursive target.
 
 $$(RESULTS_DIR)/$(strip $1)_$$(HOSTNAME)_$(strip $3)_$(strip $2): $$(GT_TARGET) | $$(OBJ_DIR) $$(RESULTS_DIR)
-	-+$$(MAKE) rec \
+	-+$$(MAKE) rec --no-print-directory \
 	  R_IS_RECURSED=True \
 	  R_CUR_COMPILER=$(strip $1) \
 	  R_CUR_OPTL=$(strip $2) \
@@ -446,9 +460,11 @@ clean:
 veryclean: distclean
 distclean: clean
 	rm -f $(DEV_TARGET)
-	find $(RESULTS_DIR) -name \*-out -delete
-	find $(RESULTS_DIR) -name \*-out\*.dat -delete
-	find $(RESULTS_DIR) -name \*-out-comparison.csv -delete
+	if [ -d "$(RESULTS_DIR)" ]; then \
+	  find "$(RESULTS_DIR)" -name \*-out -delete; \
+	  find "$(RESULTS_DIR)" -name \*-out\*.dat -delete; \
+	  find "$(RESULTS_DIR)" -name \*-out-comparison.csv -delete; \
+	fi
 	rm -f $(TARGETS)
 	rm -f $(GT_TARGET)
 	rm -f $(GT_OUT)
@@ -465,8 +481,8 @@ Makefile: $(FLIT_SCRIPT_DIR)/flit_update.py
 
 # We have a different solution if we are on a mac
 ifeq ($(UNAME_S),Darwin)
-lib/libflit.so: $(FLIT_LIB_DIR)/libflit.so
-	mkdir -p lib
+ALL_DIRS       += lib
+lib/libflit.so: $(FLIT_LIB_DIR)/libflit.so | lib
 	cp $< $@
 
 .PHONY: cleanlibflit
@@ -500,7 +516,7 @@ $(DEV_TARGET): $(DEV_OBJ) Makefile custom.mk
 $(foreach s,$(SOURCE),\
   $(eval $(call COMPILE_RULE,\
     $s,\
-    $(OBJ_DIR)/$(notdir $s)_dev.o,\
+    $(DEV_OBJ_DIR)/$(notdir $s).o,\
     $(DEV_CXX),\
     $(DEV_OPTL),\
     $(DEV_SWITCHES),\
@@ -518,7 +534,7 @@ $(GT_TARGET): $(GT_OBJ) Makefile custom.mk
 $(foreach s,$(SOURCE),\
   $(eval $(call COMPILE_RULE,\
     $s,\
-    $(OBJ_DIR)/$(notdir $s)_gt.o,\
+    $(GT_OBJ_DIR)/$(notdir $s).o,\
     $(GT_CXX),\
     $(GT_OPTL),\
     $(GT_SWITCHES),\
@@ -528,7 +544,7 @@ $(foreach s,$(SOURCE),\
 $(foreach s,$(SOURCE),\
   $(eval $(call COMPILE_RULE,\
     $s,\
-    $(OBJ_DIR)/$(notdir $s)_gt_fPIC.o,\
+    $(GT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
     $(GT_CXX),\
     $(GT_OPTL),\
     $(GT_SWITCHES),\

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -151,7 +151,7 @@ BISECT_OBJ       += $(TROUBLE_OBJ)
 TROUBLE_TARGET_DEPS := $(TROUBLE_TARGET_OBJ:%.o=%.d)
 FPIC_OBJ         := $(addprefix \
     $(BISECT_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_fPIC.o)))
-FPIC_OBJ         := $(addprefix \
+FPIC_OBJ         += $(addprefix \
     $(BISECT_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_bisect_$(TROUBLE_ID)_fPIC.o)))
 FPIC_DEPS        := $(FPIC_OBJ:%.o=%.d)
 SPLIT_OBJ        := $(addprefix \
@@ -242,12 +242,7 @@ bisect-smallclean:
 	rm -f $(TROUBLE_TARGET)
 	rm -f $(TROUBLE_TARGET_OUT)
 	rm -f $(addsuffix *.dat,$(TROUBLE_TARGET_OUT))
-	rm -f $(TROUBLE_SYMBOLS)
-	rm -f $(FPIC_OBJ)
-	rm -f $(FPIC_DEPS)
-	rm -f $(SPLIT_OBJ)
-	rm -f $(SPLIT_DEPS)
-	-rmdir $(BISECT_OBJ_DIR)
+	rm -rf $(BISECT_OBJ_DIR)
 
 bisect-clean: bisect-smallclean
 	rm -f $(TROUBLE_TARGET_OBJ)
@@ -255,7 +250,6 @@ bisect-clean: bisect-smallclean
 	rm -f $(GT_LIB_TARGET)
 	rm -f $(GT_LIB_OUT)
 	rm -f $(addsuffix *.dat,$(GT_LIB_OUT))
-	-rmdir $(BISECT_OBJ_DIR)
 
 bisect-distclean: bisect-clean
 	rm -f bisect.log

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -108,7 +108,11 @@ TROUBLE_ID       := {trouble_id}
 MAKEFILE         := {makefile}
 NUMBER           := {number}
 BISECT_DIR       := {bisect_dir}
-BISECT_OBJ_DIR   := $(BISECT_DIR)/obj
+LOCAL_OBJ_DIR    := $(BISECT_DIR)/obj
+BISECT_OBJ_DIR   := $(OBJ_DIR)/bisect/$(TROUBLE_ID)
+MORE_DIRS        += $(BISECT_DIR)
+MORE_DIRS        += $(LOCAL_OBJ_DIR)
+MORE_DIRS        += $(BISECT_OBJ_DIR)
 BISECT_TARGET    := $(BISECT_DIR)/runbisect-$(NUMBER)
 TROUBLE_TARGET   := $(BISECT_DIR)/runtrouble-$(TROUBLE_ID)
 
@@ -140,28 +144,28 @@ endif
 BUILD_GT_LOCAL   := {build_gt_local}
 
 TROUBLE_TARGET_OBJ := $(addprefix \
-    $(OBJ_DIR)/,$(notdir $(SOURCE:%=%_bisect_$(TROUBLE_ID).o)))
+    $(BISECT_OBJ_DIR)/,$(notdir $(SOURCE:%=%.o)))
 ALL_TROUBLE_FPIC := $(TROUBLE_TARGET_OBJ:%.o=%_fPIC.o)
 BISECT_GT_OBJ    := $(addprefix \
-    $(OBJ_DIR)/,$(notdir $(BISECT_GT_SRC:%=%_gt.o)))
+    $(GT_OBJ_DIR)/,$(notdir $(BISECT_GT_SRC:%=%.o)))
 TROUBLE_OBJ      := $(addprefix \
-    $(OBJ_DIR)/,$(notdir $(TROUBLE_SRC:%=%_bisect_$(TROUBLE_ID).o)))
+    $(BISECT_OBJ_DIR)/,$(notdir $(TROUBLE_SRC:%=%.o)))
 BISECT_OBJ       := $(BISECT_GT_OBJ)
 BISECT_OBJ       += $(TROUBLE_OBJ)
 TROUBLE_TARGET_DEPS := $(TROUBLE_TARGET_OBJ:%.o=%.d)
 FPIC_OBJ         := $(addprefix \
-    $(BISECT_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_fPIC.o)))
+    $(LOCAL_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_fPIC.o)))
 FPIC_OBJ         += $(addprefix \
-    $(BISECT_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_bisect_$(TROUBLE_ID)_fPIC.o)))
+    $(LOCAL_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_fPIC.o)))
 FPIC_DEPS        := $(FPIC_OBJ:%.o=%.d)
 SPLIT_OBJ        := $(addprefix \
-    $(BISECT_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_split_$(NUMBER).o)))
+    $(LOCAL_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_split_$(NUMBER).o)))
 SPLIT_OBJ        += $(addprefix \
-    $(BISECT_OBJ_DIR)/,$(notdir \
+    $(LOCAL_OBJ_DIR)/,$(notdir \
       $(SPLIT_SRC:%=%_trouble_split_$(NUMBER).o)))
 SPLIT_DEPS       := $(SPLIT_OBJ:%.o=%.d)
 TROUBLE_SYMBOLS  := $(addprefix \
-    $(BISECT_OBJ_DIR)/,$(notdir \
+    $(LOCAL_OBJ_DIR)/,$(notdir \
       $(SPLIT_SRC:%=%_trouble_symbols_$(NUMBER).txt)))
 
 TROUBLE_TARGET_OUT := $(TROUBLE_TARGET:%=%-out)
@@ -242,7 +246,7 @@ bisect-smallclean:
 	rm -f $(TROUBLE_TARGET)
 	rm -f $(TROUBLE_TARGET_OUT)
 	rm -f $(addsuffix *.dat,$(TROUBLE_TARGET_OUT))
-	rm -rf $(BISECT_OBJ_DIR)
+	rm -rf $(LOCAL_OBJ_DIR)
 
 bisect-clean: bisect-smallclean
 	rm -f $(TROUBLE_TARGET_OBJ)
@@ -258,40 +262,41 @@ bisect-distclean: bisect-clean
 	rm -f $(MAKEFILE)
 	-rmdir $(BISECT_DIR)
 
-$(BISECT_DIR):
-	mkdir -p $(BISECT_DIR)
+dirs: $(MORE_DIRS)
 
-$(BISECT_OBJ_DIR):
-	mkdir -p $(BISECT_OBJ_DIR)
+$(MORE_DIRS):
+	mkdir -p $@
 
 # Copied mostly from Makefile.in COMPILE_RULE, but customized for bisect
 # Compiles a single object file with -fPIC, checking first for a precompiled
 # version (and if so, copy it instead of recompiling).
 # @param 1: source file
 # @param 2: object file
-# @param 3: compiler
-# @param 4: optimization level
-# @param 5: switches
-# @param 6: target filename
-# @param 7: extra compiler flags
+# @param 3: other object file location
+# @param 4: compiler
+# @param 5: optimization level
+# @param 6: switches
+# @param 7: target filename
+# @param 8: extra compiler flags
 define FPIC_COMPILE_RULE
-$2: $1 Makefile custom.mk | $(BISECT_OBJ_DIR)
-	if [ -f "$(OBJ_DIR)/$(notdir $(strip 2))" ]; then \
-	  ln -s "../../$(OBJ_DIR)/$(notdir $(strip 2))" "$(strip $2)"; \
+$2: $1 Makefile custom.mk | $(LOCAL_OBJ_DIR)
+	if [ -f "$3" ]; then \
+	  ln -s "../../$(strip 3)" "$(strip $2)"; \
 	else \
-	  $3 $4 $5 -c $7 $(CC_REQUIRED) -fPIC $(DEPFLAGS) $(2:%.o=%.d) $1 -o $2 \
+	  $4 $5 $6 -c $8 $(CC_REQUIRED) -fPIC $(DEPFLAGS) $(2:%.o=%.d) $1 -o $2 \
 	    -DFLIT_HOST='"$(HOSTNAME)"' \
-	    -DFLIT_COMPILER='"$(strip $3)"' \
-	    -DFLIT_OPTL='"$(strip $4)"' \
-	    -DFLIT_SWITCHES='"$(strip $5)"' \
-	    -DFLIT_FILENAME='"$(notdir $(strip $6))"'; \
+	    -DFLIT_COMPILER='"$(strip $4)"' \
+	    -DFLIT_OPTL='"$(strip $5)"' \
+	    -DFLIT_SWITCHES='"$(strip $6)"' \
+	    -DFLIT_FILENAME='"$(notdir $(strip $7))"'; \
 	fi
 endef
 
 $(foreach s,$(SOURCE),\
   $(eval $(call FPIC_COMPILE_RULE,\
     $s,\
-    $(BISECT_OBJ_DIR)/$(notdir $s)_gt_fPIC.o,\
+    $(LOCAL_OBJ_DIR)/$(notdir $s)_gt_fPIC.o,\
+		$(GT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
     $(GT_CXX),\
     $(GT_OPTL),\
     $(GT_SWITCHES),\
@@ -302,7 +307,7 @@ $(foreach s,$(SOURCE),\
 $(foreach s,$(SOURCE),\
   $(eval $(call COMPILE_RULE,\
     $s,\
-    $(OBJ_DIR)/$(notdir $s)_bisect_$(TROUBLE_ID).o,\
+    $(BISECT_OBJ_DIR)/$(notdir $s).o,\
     $(TROUBLE_CXX),\
     $(TROUBLE_OPTL),\
     $(TROUBLE_SWITCHES),\
@@ -313,18 +318,19 @@ $(foreach s,$(SOURCE),\
 $(foreach s,$(SOURCE),\
   $(eval $(call FPIC_COMPILE_RULE,\
     $s,\
-    $(BISECT_OBJ_DIR)/$(notdir $s)_bisect_$(TROUBLE_ID)_fPIC.o,\
+    $(LOCAL_OBJ_DIR)/$(notdir $s)_fPIC.o,\
+		$(BISECT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
     $(TROUBLE_CXX),\
     $(TROUBLE_OPTL),\
     $(TROUBLE_SWITCHES),\
     bisect-default-out,\
     $(TROUBLE_CFLAGS))))
 
-# The fPIC variant built in OBJ_DIR instead of BISECT_OBJ_DIR
+# The fPIC variant built in OBJ_DIR instead of LOCAL_OBJ_DIR
 $(foreach s,$(SOURCE),\
   $(eval $(call COMPILE_RULE,\
     $s,\
-    $(OBJ_DIR)/$(notdir $s)_bisect_$(TROUBLE_ID)_fPIC.o,\
+    $(BISECT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
     $(TROUBLE_CXX),\
     $(TROUBLE_OPTL),\
     $(TROUBLE_SWITCHES),\
@@ -338,34 +344,34 @@ $(foreach s,$(SOURCE),\
 #     'Example01.cpp')
 define SPLIT_RULE
 
-$$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(BISECT_OBJ_DIR)/$1_gt_fPIC.o
-$$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(BISECT_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt
-$$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(MAKEFILE)
-$$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: | $$(BISECT_OBJ_DIR)
-	if [ -s "$$(BISECT_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt" ]; then \
+$$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(LOCAL_OBJ_DIR)/$1_gt_fPIC.o
+$$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(LOCAL_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt
+$$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(MAKEFILE)
+$$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: | $$(LOCAL_OBJ_DIR)
+	if [ -s "$$(LOCAL_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt" ]; then \
 	  objcopy \
-	    --weaken-symbols=$$(BISECT_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt \
-	    $$(BISECT_OBJ_DIR)/$1_gt_fPIC.o \
-	    $$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o; \
+	    --weaken-symbols=$$(LOCAL_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt \
+	    $$(LOCAL_OBJ_DIR)/$1_gt_fPIC.o \
+	    $$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o; \
 	else \
 	  cp \
-	    $$(BISECT_OBJ_DIR)/$1_gt_fPIC.o \
-	    $$(BISECT_OBJ_DIR)/$1_gt_split_$$(NUMBER).o; \
+	    $$(LOCAL_OBJ_DIR)/$1_gt_fPIC.o \
+	    $$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o; \
 	fi
 
-$$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(BISECT_OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o
-$$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(MAKEFILE)
-$$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(BISECT_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt
-$$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: | $$(BISECT_OBJ_DIR)
-	if [ -s "$$(BISECT_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt" ]; then \
+$$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(LOCAL_OBJ_DIR)/$1_fPIC.o
+$$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(MAKEFILE)
+$$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(LOCAL_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt
+$$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: | $$(LOCAL_OBJ_DIR)
+	if [ -s "$$(LOCAL_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt" ]; then \
 	  objcopy \
-	    --weaken-symbols=$$(BISECT_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt \
-	    $$(BISECT_OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o \
-	    $$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o; \
+	    --weaken-symbols=$$(LOCAL_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt \
+	    $$(LOCAL_OBJ_DIR)/$1_fPIC.o \
+	    $$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o; \
 	else \
 	  cp \
-	    $$(BISECT_OBJ_DIR)/$1_bisect_$$(TROUBLE_ID)_fPIC.o \
-	    $$(BISECT_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o; \
+	    $$(LOCAL_OBJ_DIR)/$1_fPIC.o \
+	    $$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o; \
 	fi
 
 endef

--- a/documentation/test-executable.md
+++ b/documentation/test-executable.md
@@ -32,7 +32,8 @@ update`.
   Separated from doing the run because you may not want to execute tests in
   parallel in case (1) there is contention between them, or (2) they would
   interfere with proper timing measurements.  The compiled executables will be
-  placed in the `results` directory.
+  placed in the `bin` directory.  You may build in parallel using this target
+  and then run sequentially using the `run` target.
 - **run:** Build and execute all of the tests under all combinations of
   compilers, optimization levels, and flags.  If the **runbuild** target has
   already been invoked, then this only runs the tests and generates results
@@ -40,7 +41,7 @@ update`.
 - **clean:** Remove all intermediate files such as object files.  Does not
   remove executables or results.
 - **distclean:** Remove everything including executables and results (but not
-  the database).
+  the results database).
 
 ## Test Executable Details
 

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -566,8 +566,7 @@ _extract_symbols_memos = {}
 def extract_symbols(file_or_filelist, objdir):
     '''
     Extracts symbols for the given source file(s).  The corresponding object is
-    assumed to be in the objdir with the filename replaced with the GNU Make
-    pattern %=%_gt.o.
+    assumed to be in the objdir with ".o" appended to the end of the filename.
 
     @param file_or_filelist: (str or list(str)) source file(s) for which to get
         symbols.
@@ -593,7 +592,7 @@ def extract_symbols(file_or_filelist, objdir):
     # now we know it is a string, so assume it is a filename
     fname = file_or_filelist
     fbase = os.path.basename(fname)
-    fobj = os.path.join(objdir, fbase + '_gt.o')
+    fobj = os.path.join(objdir, fbase + '.o')
 
     if fobj in _extract_symbols_memos:
         return _extract_symbols_memos[fobj]
@@ -1369,7 +1368,8 @@ def search_for_symbol_problems(args, bisect_path, replacements, sources,
                  indent)
     logging.debug('%sSymbols:', indent)
     fsymbol_tuples, remaining_symbols = \
-        extract_symbols(differing_source, os.path.join(args.directory, 'obj'))
+        extract_symbols(differing_source,
+                        os.path.join(args.directory, 'obj', 'gt'))
     for sym in fsymbol_tuples:
         message = '{indent}  {sym.fname}:{sym.lineno} {sym.symbol} ' \
                   '-- {sym.demangled}'.format(indent=indent, sym=sym)
@@ -1773,7 +1773,7 @@ def run_bisect(arguments, prog=sys.argv[0]):
             logging.info('%s', message)
             fsymbol_tuples, remaining_symbols = \
                 extract_symbols([x[0] for x in differing_sources],
-                                os.path.join(args.directory, 'obj'))
+                                os.path.join(args.directory, 'obj', 'gt'))
             checker = _gen_bisect_symbol_checker(
                 args, bisect_path, replacements, sources, fsymbol_tuples,
                 remaining_symbols)

--- a/tests/flit_install/tst_install_runthrough.py
+++ b/tests/flit_install/tst_install_runthrough.py
@@ -86,24 +86,24 @@ Tests FLiT's capabilities to run simple commands on an installation
 The tests are below using doctest
 
 Let's now make a temporary directory and install there.  Here we are simply
-testing that the following command complete without error.
+testing that the following commands complete without error.
 >>> import glob
 >>> import os
 >>> import subprocess as subp
 >>> with th.tempdir() as temp_dir:
-...     _ = subp.check_call(['make', '-C', os.path.join(th.config.lib_dir, '..'),
+...     _ = subp.check_call(['make',
+...                          '-C', os.path.join(th.config.lib_dir, '..'),
 ...                          'install', 'PREFIX=' + temp_dir],
 ...                         stdout=subp.DEVNULL, stderr=subp.DEVNULL)
 ...     flit = os.path.join(temp_dir, 'bin', 'flit')
-...     _ = subp.check_call([flit, 'init', '-C', os.path.join(temp_dir, 'sandbox')],
+...     sandbox_dir = os.path.join(temp_dir, 'sandbox')
+...     _ = subp.check_call([flit, 'init', '-C', sandbox_dir],
 ...                         stdout=subp.DEVNULL, stderr=subp.DEVNULL)
-...     _ = subp.check_call(['mkdir', '-p', os.path.join(temp_dir, 'sandbox', 'obj'),
-...                          os.path.join(temp_dir, 'sandbox', 'results')],
+...     _ = subp.check_call(['make', '-C', sandbox_dir, 'dirs'],
 ...                         stdout=subp.DEVNULL, stderr=subp.DEVNULL)
-...     _ = subp.check_call(['make', '-C', os.path.join(temp_dir, 'sandbox'),
-...                          '--touch', 'run'],
+...     _ = subp.check_call(['make', '-C', sandbox_dir, '--touch', 'run'],
 ...                         stdout=subp.DEVNULL, stderr=subp.DEVNULL)
-...     os.chdir(os.path.join(temp_dir, 'sandbox'))
+...     os.chdir(sandbox_dir)
 ...     _ = subp.check_call([flit, 'import'] + glob.glob('results/*.csv'),
 ...                         stdout=subp.DEVNULL, stderr=subp.DEVNULL)
 '''

--- a/tests/flit_makefile/tst_empty_project.py
+++ b/tests/flit_makefile/tst_empty_project.py
@@ -129,7 +129,31 @@ True
 True
 >>> '-DFLIT_FILENAME=\\'"devrun"\\'' in actual
 True
->>> '-o devrun obj/main.cpp_dev.o obj/Empty.cpp_dev.o' in actual
+>>> '-o devrun obj/dev/main.cpp.o obj/dev/Empty.cpp.o' in actual
+True
+>>> '-lm -lstdc++ -L{libdir} -lflit -Wl,-rpath={libdir}' \\
+... .format(libdir=th.config.lib_dir) in actual
+True
+
+The same test, but with the 'gt' target
+
+>>> import subprocess as subp
+>>> with th.tempdir() as temp_dir:
+...     th.flit.main(['init', '-C', temp_dir]) # doctest:+ELLIPSIS
+...     actual = subp.check_output(['make', '-C', temp_dir, '-n', 'gt'])
+Creating ...
+>>> actual = actual.decode('utf-8').strip()
+>>> '-DFLIT_HOST=' in actual
+True
+>>> '-DFLIT_COMPILER=\\'"g++"\\'' in actual
+True
+>>> '-DFLIT_OPTL=\\'"-O0"\\'' in actual
+True
+>>> '-DFLIT_SWITCHES=\\'""\\'' in actual
+True
+>>> '-DFLIT_FILENAME=\\'"gtrun"\\'' in actual
+True
+>>> '-o gtrun obj/gt/main.cpp.o obj/gt/Empty.cpp.o' in actual
 True
 >>> '-lm -lstdc++ -L{libdir} -lflit -Wl,-rpath={libdir}' \\
 ... .format(libdir=th.config.lib_dir) in actual

--- a/tests/flit_makefile/tst_incremental_build.py
+++ b/tests/flit_makefile/tst_incremental_build.py
@@ -95,24 +95,27 @@ The tests are below using doctest
 Test that the dev target will be rebuilt if one of the files is updated.
 We use 'make --touch' to simply touch files it would create and then we will
 test that the correct files are updated.
->>> def compile_target(directory, target):
+>>> def compile_target(directory, target, touch=True):
 ...     'Compiles the dev target using "make --touch" and returns the output'
-...     output = subp.check_output(['make', '-C', directory, '--touch', target])
+...     command = ['make', '-C', directory, target]
+...     if touch:
+...         command.append('--touch')
+...     output = subp.check_output(command)
 ...     return output.decode('utf-8').strip()
 >>> compile_dev = lambda x: compile_target(x, 'dev')
 >>> with th.tempdir() as temp_dir:
 ...     th.flit.main(['init', '-C', temp_dir]) # doctest:+ELLIPSIS
 ...     # fake the built elements -- don't actually build for time's sake
-...     os.mkdir(os.path.join(temp_dir, 'obj'))
+...     _ = compile_target(temp_dir, 'dirs', touch=False)
 ...     before_build = compile_dev(temp_dir)
 ...     # this next build should say nothing to do
 ...     after_build = compile_dev(temp_dir)
 ...     # update one file and recompile
 ...     with open(os.path.join(temp_dir, 'main.cpp'), 'a') as mainfile:
 ...         mainfile.write('#include "new_header.h"\\n')
-...     maindepname = os.path.join(temp_dir, 'obj', 'main.cpp_dev.d')
+...     maindepname = os.path.join(temp_dir, 'obj', 'dev', 'main.cpp.d')
 ...     with open(maindepname, 'w') as maindep:
-...         maindep.write('obj/main.cpp_dev.o: main.cpp new_header.h\\n')
+...         maindep.write('obj/dev/main.cpp.o: main.cpp new_header.h\\n')
 ...     th.touch(os.path.join(temp_dir, 'new_header.h'))
 ...     after_modify = compile_dev(temp_dir)
 ...     # touch the header file and make sure it recompiles again
@@ -129,16 +132,16 @@ Creating ...
 Make sure all of the correct files were created with our build commands
 
 >>> touched_files(before_build)
-['devrun', 'obj/Empty.cpp_dev.o', 'obj/main.cpp_dev.o']
+['devrun', 'obj/dev/Empty.cpp.o', 'obj/dev/main.cpp.o']
 
 >>> touched_files(after_build)
 []
 
 >>> touched_files(after_modify)
-['devrun', 'obj/main.cpp_dev.o']
+['devrun', 'obj/dev/main.cpp.o']
 
 >>> touched_files(after_touch)
-['devrun', 'obj/main.cpp_dev.o']
+['devrun', 'obj/dev/main.cpp.o']
 
 Now, let's test the same thing with the "gt" target
 
@@ -146,16 +149,16 @@ Now, let's test the same thing with the "gt" target
 >>> with th.tempdir() as temp_dir:
 ...     th.flit.main(['init', '-C', temp_dir]) # doctest:+ELLIPSIS
 ...     # fake the built elements -- don't actually build for time's sake
-...     os.mkdir(os.path.join(temp_dir, 'obj'))
+...     compile_target(temp_dir, 'dirs', touch=False)
 ...     before_build = compile_gt(temp_dir)
 ...     # this next build should say nothing to do
 ...     after_build = compile_gt(temp_dir)
 ...     # update one file and recompile
 ...     with open(os.path.join(temp_dir, 'main.cpp'), 'a') as mainfile:
 ...         mainfile.write('#include "new_header.h"\\n')
-...     maindepname = os.path.join(temp_dir, 'obj', 'main.cpp_gt.d')
+...     maindepname = os.path.join(temp_dir, 'obj', 'gt', 'main.cpp.d')
 ...     with open(maindepname, 'w') as maindep:
-...         maindep.write('obj/main.cpp_gt.o: main.cpp new_header.h\\n')
+...         maindep.write('obj/gt/main.cpp.o: main.cpp new_header.h\\n')
 ...     th.touch(os.path.join(temp_dir, 'new_header.h'))
 ...     after_modify = compile_gt(temp_dir)
 ...     # touch the header file and make sure it recompiles again
@@ -167,16 +170,16 @@ Creating ...
 Make sure all of the correct files were created with our build commands
 
 >>> touched_files(before_build)
-['gtrun', 'obj/Empty.cpp_gt.o', 'obj/main.cpp_gt.o']
+['gtrun', 'obj/gt/Empty.cpp.o', 'obj/gt/main.cpp.o']
 
 >>> touched_files(after_build)
 []
 
 >>> touched_files(after_modify)
-['gtrun', 'obj/main.cpp_gt.o']
+['gtrun', 'obj/gt/main.cpp.o']
 
 >>> touched_files(after_touch)
-['gtrun', 'obj/main.cpp_gt.o']
+['gtrun', 'obj/gt/main.cpp.o']
 '''
 
 # Test setup before the docstring is run.


### PR DESCRIPTION
Fixes #269

**Description:**
Initially, this change was to simply delete the `obj` dir when invoking `make clean`.  But I took the opportunity to refactor how object files and binaries are generated and updated the whole directory structure of the build.  Here is a list of things I changed:

- Put executables compiled with `runbuild` into a separate directory called `bin`.  This makes cleanup easier by simply deleting the `bin` directory.  Also, it separates the compiled executables from the results.
- Make a separate subdirectory within `obj` (for object files and dependency files) for each compilation.  The `gtrun` executable will have `obj/gt/`, the `devrun` executable will have `obj/dev/`, flit run executables will have `obj/<ID>/`, and bisect runs will have `obj/bisect/<ID>`.
- From `make clean`, simply perform `rm -rf obj`.
- From `make distclean`, simply perform `rm -rf bin` and `rm -rf results`, as well as removing `gtrun` and `devrun`.
- Add a `make dirs` target that creates all necessary empty directories.  This is useful when using `make --touch <target>` because in order to touch files, the directories must already exist.

Here is a tree after calling `make run` on an empty project (with a small compilation search space):

```
.
├── bin
│   ├── CLANG_yoga-manjaro_FFLOAT_STORE_O1
│   ├── GCC_yoga-manjaro_FASSOCIATIVE_MATH_O2
│   ├── GCC_yoga-manjaro_FASSOCIATIVE_MATH_O3
│   ├── GCC_yoga-manjaro_NO_FLAGS_O2
│   └── GCC_yoga-manjaro_NO_FLAGS_O3
├── custom.mk
├── flit-config.toml
├── ground-truth.csv
├── gtrun
├── main.cpp
├── Makefile
├── obj
│   ├── CLANG_yoga-manjaro_FFLOAT_STORE_O1
│   │   ├── Empty.cpp.d
│   │   ├── Empty.cpp.o
│   │   ├── main.cpp.d
│   │   └── main.cpp.o
│   ├── GCC_yoga-manjaro_FASSOCIATIVE_MATH_O2
│   │   ├── Empty.cpp.d
│   │   ├── Empty.cpp.o
│   │   ├── main.cpp.d
│   │   └── main.cpp.o
│   ├── GCC_yoga-manjaro_FASSOCIATIVE_MATH_O3
│   │   ├── Empty.cpp.d
│   │   ├── Empty.cpp.o
│   │   ├── main.cpp.d
│   │   └── main.cpp.o
│   ├── GCC_yoga-manjaro_NO_FLAGS_O2
│   │   ├── Empty.cpp.d
│   │   ├── Empty.cpp.o
│   │   ├── main.cpp.d
│   │   └── main.cpp.o
│   ├── GCC_yoga-manjaro_NO_FLAGS_O3
│   │   ├── Empty.cpp.d
│   │   ├── Empty.cpp.o
│   │   ├── main.cpp.d
│   │   └── main.cpp.o
│   └── gt
│       ├── Empty.cpp.d
│       ├── Empty.cpp.o
│       ├── main.cpp.d
│       └── main.cpp.o
├── results
│   ├── CLANG_yoga-manjaro_FFLOAT_STORE_O1-out
│   ├── CLANG_yoga-manjaro_FFLOAT_STORE_O1-out-comparison.csv
│   ├── GCC_yoga-manjaro_FASSOCIATIVE_MATH_O2-out
│   ├── GCC_yoga-manjaro_FASSOCIATIVE_MATH_O2-out-comparison.csv
│   ├── GCC_yoga-manjaro_FASSOCIATIVE_MATH_O3-out
│   ├── GCC_yoga-manjaro_FASSOCIATIVE_MATH_O3-out-comparison.csv
│   ├── GCC_yoga-manjaro_NO_FLAGS_O2-out
│   ├── GCC_yoga-manjaro_NO_FLAGS_O2-out-comparison.csv
│   ├── GCC_yoga-manjaro_NO_FLAGS_O3-out
│   └── GCC_yoga-manjaro_NO_FLAGS_O3-out-comparison.csv
└── tests
    └── Empty.cpp
```

**Documentation:**
Just updated where compiled executables are generated.  The documentation said into the `results` directory, which is now updated to the `bin` directory.  Not much else was changed since this is more of an internal organization rather than a user-interface piece.

**Tests:**
No new tests were created, but existing tests were updated for the new directory structure.  All tests pass.