### PR TITLE
fix FLIT_REGISTER_MAIN()

### DIFF
--- a/src/TestBase.h
+++ b/src/TestBase.h
@@ -483,6 +483,13 @@ inline std::shared_ptr<TestBase<long double>> TestFactory::get<long double> () {
 std::map<std::string, TestFactory*>& getTests();
 
 inline void registerTest(const std::string& name, TestFactory *factory) {
+  if (factory == nullptr) {
+    throw std::invalid_argument("factory pointer is null");
+  }
+  if (getTests().count(name) > 0 && getTests()[name] != factory) {
+    throw std::logic_error("factory is already registered to a different "
+                           "pointer: " + name);
+  }
   getTests()[name] = factory;
 }
 

--- a/src/subprocess.cpp
+++ b/src/subprocess.cpp
@@ -77,11 +77,16 @@ void register_main_func(const std::string &main_name, MainFunc* main_func) {
   if (main_func == nullptr) {
     throw std::invalid_argument("Main func is null");
   }
-  if (main_name_map.find(main_name) != main_name_map.end()) {
-    throw std::logic_error("Main name already registered: " + main_name);
+  auto tmp_func = main_name_map.find(main_name);
+  if (tmp_func != main_name_map.end() && tmp_func->second != main_func) {
+    throw std::logic_error("Main name already registered "
+                           "to a different function: " + main_name);
   }
-  if (main_func_map.find(main_func) != main_func_map.end()) {
-    throw std::logic_error("Main func already registered with " + main_name);
+  auto tmp_name = main_func_map.find(main_func);
+  if (tmp_name != main_func_map.end() && tmp_name->second != main_name) {
+    throw std::logic_error("Main func already registered "
+                           "with a different name: " + main_name
+                           + " != " + tmp_name->second);
   }
   main_name_map[main_name] = main_func;
   main_func_map[main_func] = main_name;

--- a/tests/flit_src/tst_TestBase.cpp
+++ b/tests/flit_src/tst_TestBase.cpp
@@ -673,3 +673,122 @@ TH_REGISTER(tst_TestBase_run_outputVariantsToFile);
 
 } // end of namespace TestBase
 
+namespace TestFactory {
+
+class NullTestFactory : public flit::TestFactory {
+public:
+  int create_count = 0;
+protected:
+  virtual createType create() override {
+    create_count++;
+    return std::make_tuple(
+        std::make_shared<flit::NullTest<float>>("NullTest"),
+        std::make_shared<flit::NullTest<double>>("NullTest"),
+        std::make_shared<flit::NullTest<long double>>("NullTest")
+        );
+  }
+};
+
+void tst_TestFactory_get() {
+  // calling get<float>() creates them
+  NullTestFactory factory1;
+  TH_EQUAL(0, factory1.create_count);
+
+  auto null_float = factory1.get<float>();
+  TH_EQUAL(1, factory1.create_count);
+  TH_NOT_EQUAL(nullptr, null_float.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<float>*>(null_float.get()));
+
+  auto null_double = factory1.get<double>();
+  TH_EQUAL(1, factory1.create_count);
+  TH_NOT_EQUAL(nullptr, null_double.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<double>*>(null_double.get()));
+
+  auto null_ldouble = factory1.get<long double>();
+  TH_EQUAL(1, factory1.create_count);
+  TH_NOT_EQUAL(nullptr, null_ldouble.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<long double>*>(null_ldouble.get()));
+
+  // calling get<double>() creates them
+  NullTestFactory factory2;
+  TH_EQUAL(0, factory2.create_count);
+
+  null_double = factory2.get<double>();
+  TH_EQUAL(1, factory2.create_count);
+  TH_NOT_EQUAL(nullptr, null_double.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<double>*>(null_double.get()));
+
+  null_float = factory2.get<float>();
+  TH_EQUAL(1, factory2.create_count);
+  TH_NOT_EQUAL(nullptr, null_float.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<float>*>(null_float.get()));
+
+  null_ldouble = factory2.get<long double>();
+  TH_EQUAL(1, factory2.create_count);
+  TH_NOT_EQUAL(nullptr, null_ldouble.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<long double>*>(null_ldouble.get()));
+
+  // calling get<long double>() creates them
+  NullTestFactory factory3;
+  TH_EQUAL(0, factory3.create_count);
+
+  null_ldouble = factory3.get<long double>();
+  TH_EQUAL(1, factory3.create_count);
+  TH_NOT_EQUAL(nullptr, null_ldouble.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<long double>*>(null_ldouble.get()));
+
+  null_double = factory3.get<double>();
+  TH_EQUAL(1, factory3.create_count);
+  TH_NOT_EQUAL(nullptr, null_double.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<double>*>(null_double.get()));
+
+  null_float = factory3.get<float>();
+  TH_EQUAL(1, factory3.create_count);
+  TH_NOT_EQUAL(nullptr, null_float.get());
+  TH_NOT_EQUAL(nullptr,
+               dynamic_cast<flit::NullTest<float>*>(null_float.get()));
+}
+TH_REGISTER(tst_TestFactory_get);
+
+} // end of namespace TestFactory
+
+namespace Functions {
+
+void tst_registerTest() {
+  TestFactory::NullTestFactory factory;
+
+  // Test the registration works
+  // Reregistering with the same pointer is fine
+  TH_EQUAL(0, flit::getTests().count("factory"));
+  flit::registerTest("factory", &factory);
+  TH_EQUAL(1, flit::getTests().count("factory"));
+  flit::registerTest("factory", &factory);
+  TH_EQUAL(1, flit::getTests().count("factory"));
+
+  // Test the registration works for a second one
+  TH_EQUAL(0, flit::getTests().count("factory2"));
+  flit::registerTest("factory2", &factory);
+  TH_EQUAL(1, flit::getTests().count("factory2"));
+  flit::registerTest("factory2", &factory);
+  TH_EQUAL(1, flit::getTests().count("factory"));
+
+  // Reregistering a factory name with a different factory is fine
+  TestFactory::NullTestFactory another_factory;
+  TH_THROWS(flit::registerTest("factory", &another_factory), std::logic_error);
+
+  // Registering a nullptr throws
+  TH_THROWS(flit::registerTest("another_factory", nullptr),
+            std::invalid_argument);
+}
+TH_REGISTER(tst_registerTest);
+
+} // end of namespace Functions
+

--- a/tests/flit_src/tst_subprocess.cpp
+++ b/tests/flit_src/tst_subprocess.cpp
@@ -210,6 +210,27 @@ void tst_register_main_func() {
 }
 TH_REGISTER(tst_register_main_func);
 
+int othermain_1(int, char**) { return 0; }
+int othermain_2(int, char**) { return 0; }
+
+void tst_register_main_duplicate_func() {
+  // register the main functions
+  flit::register_main_func("othermain_1", othermain_1);
+  flit::register_main_func("othermain_2", othermain_2);
+
+  // test that registering already registered things are okay, as long as they
+  // match.
+  flit::register_main_func("othermain_1", othermain_1);
+  flit::register_main_func("othermain_2", othermain_2);
+
+  // test that registering already registered things with new mappings is an
+  // error.
+  TH_THROWS(flit::register_main_func("othermain_2", othermain_1),
+            std::logic_error);
+  TH_THROWS(flit::register_main_func("othermain_1", othermain_2),
+            std::logic_error);
+}
+
 // This test sufficiently exercises isFastTrack() and callFastTrack()
 // Therefore, we do not need to test those functions in isolation
 void tst_call_main() {


### PR DESCRIPTION
allow it to be called more than once with the same args

Fixes #273

**Description:**
The fix for issue #272 broke one aspect of bisect functionality.  That is when the file being run with symbol bisect is the test file itself, which is not unusual if the file containing `main()` to be tested is susceptible to variability-inducing compiler optimizations.

Because this fixes a problem with the implementation of issue #272, we are doing the pull request with that feature branch before merging it into `devel`.

This change allows `flit::registerMain()` to be called multiple times as long as they are with identical arguments.

Did the same for `flit::registerTest()`.

**Documentation:**
No change necessary.  This is already the expected behavior that we are fixing.

**Tests:**
Added automated tests for `flit::registerMain()` and `flit::registerTest()`.  These tests failed before the change, and now all pass.