### PR TITLE
Issue283 bisect deletes fpic

### DIFF
--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -368,7 +368,7 @@ dirs: $(ALL_DIRS)
 $(ALL_DIRS):
 	@$(call color_out_noline,CYAN,  mkdir)
 	@echo " $@"
-	mkdir -p $@
+	+mkdir -p $@
 
 # If we are in a recursion
 ifdef R_IS_RECURSED

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -328,7 +328,7 @@ R_CUR_SWITCHES  ?=
 dirs: $(ALL_DIRS)
 
 $(ALL_DIRS):
-	mkdir -p $@
+	+mkdir -p $@
 
 # If we are in a recursion
 ifdef R_IS_RECURSED

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -102,6 +102,8 @@ TROUBLE_OPTL     := {trouble_optl}
 TROUBLE_SWITCHES := {trouble_switches}
 TROUBLE_CXX_TYPE := {trouble_type}
 BISECT_LINK      := $(GT_CXX)
+RM               := rm -f
+RMDIR            := rm -rf
 
 TROUBLE_ID       := {trouble_id}
 
@@ -109,9 +111,16 @@ MAKEFILE         := {makefile}
 NUMBER           := {number}
 BISECT_DIR       := {bisect_dir}
 LOCAL_OBJ_DIR    := $(BISECT_DIR)/obj
+FPIC_DIR         := $(LOCAL_OBJ_DIR)/fpic
+SPLIT_DIR        := $(LOCAL_OBJ_DIR)/split
+SYMBOLS_DIR      := $(LOCAL_OBJ_DIR)/symbols
+
 BISECT_OBJ_DIR   := $(OBJ_DIR)/bisect/$(TROUBLE_ID)
 MORE_DIRS        += $(BISECT_DIR)
 MORE_DIRS        += $(LOCAL_OBJ_DIR)
+MORE_DIRS        += $(FPIC_DIR)
+MORE_DIRS        += $(SPLIT_DIR)
+MORE_DIRS        += $(SYMBOLS_DIR)
 MORE_DIRS        += $(BISECT_OBJ_DIR)
 BISECT_TARGET    := $(BISECT_DIR)/runbisect-$(NUMBER)
 TROUBLE_TARGET   := $(BISECT_DIR)/runtrouble-$(TROUBLE_ID)
@@ -154,18 +163,18 @@ BISECT_OBJ       := $(BISECT_GT_OBJ)
 BISECT_OBJ       += $(TROUBLE_OBJ)
 TROUBLE_TARGET_DEPS := $(TROUBLE_TARGET_OBJ:%.o=%.d)
 FPIC_OBJ         := $(addprefix \
-    $(LOCAL_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_fPIC.o)))
+    $(FPIC_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_fPIC.o)))
 FPIC_OBJ         += $(addprefix \
-    $(LOCAL_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_fPIC.o)))
+    $(FPIC_DIR)/,$(notdir $(SPLIT_SRC:%=%_fPIC.o)))
 FPIC_DEPS        := $(FPIC_OBJ:%.o=%.d)
 SPLIT_OBJ        := $(addprefix \
-    $(LOCAL_OBJ_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_split_$(NUMBER).o)))
+    $(SPLIT_DIR)/,$(notdir $(SPLIT_SRC:%=%_gt_split_$(NUMBER).o)))
 SPLIT_OBJ        += $(addprefix \
-    $(LOCAL_OBJ_DIR)/,$(notdir \
+    $(SPLIT_DIR)/,$(notdir \
       $(SPLIT_SRC:%=%_trouble_split_$(NUMBER).o)))
 SPLIT_DEPS       := $(SPLIT_OBJ:%.o=%.d)
 TROUBLE_SYMBOLS  := $(addprefix \
-    $(LOCAL_OBJ_DIR)/,$(notdir \
+    $(SYMBOLS_DIR)/,$(notdir \
       $(SPLIT_SRC:%=%_trouble_symbols_$(NUMBER).txt)))
 
 TROUBLE_TARGET_OUT := $(TROUBLE_TARGET:%=%-out)
@@ -242,27 +251,30 @@ bisect: $(BISECT_RESULT) $(BISECT_OUT)
 clean: bisect-clean
 distclean: bisect-distclean
 bisect-smallclean:
-	rm -f $(BISECT_TARGET)
-	rm -f $(BISECT_OUT)
-	rm -f $(addsuffix *.dat,$(BISECT_OUT))
-	rm -f $(TROUBLE_TARGET)
-	rm -f $(TROUBLE_TARGET_OUT)
-	rm -f $(addsuffix *.dat,$(TROUBLE_TARGET_OUT))
-	rm -rf $(LOCAL_OBJ_DIR)
+	$(RM) $(BISECT_TARGET)
+	$(RM) $(BISECT_OUT)
+	$(RM) $(addsuffix *.dat,$(BISECT_OUT))
+	$(RM) $(TROUBLE_TARGET)
+	$(RM) $(TROUBLE_TARGET_OUT)
+	$(RM) $(addsuffix *.dat,$(TROUBLE_TARGET_OUT))
+	$(RMDIR) $(SPLIT_DIR)
 
 bisect-clean: bisect-smallclean
-	rm -f $(TROUBLE_TARGET_OBJ)
-	rm -f $(TROUBLE_TARGET_DEPS)
-	rm -f $(GT_LIB_TARGET)
-	rm -f $(GT_LIB_OUT)
-	rm -f $(addsuffix *.dat,$(GT_LIB_OUT))
+	$(RM) $(TROUBLE_TARGET_OBJ)
+	$(RM) $(TROUBLE_TARGET_DEPS)
+	$(RM) $(GT_LIB_TARGET)
+	$(RM) $(GT_LIB_OUT)
+	$(RM) $(addsuffix *.dat,$(GT_LIB_OUT))
+	$(RMDIR) $(FPIC_DIR)
 
 bisect-distclean: bisect-clean
-	rm -f bisect.log
-	rm -f $(TROUBLE_TARGET_RESULT)
-	rm -f $(BISECT_RESULT)
-	rm -f $(MAKEFILE)
-	-rmdir $(BISECT_DIR)
+	$(RM) bisect.log
+	$(RM) $(TROUBLE_TARGET_RESULT)
+	$(RM) $(BISECT_RESULT)
+	$(RM) $(MAKEFILE)
+	$(RMDIR) $(SYMBOLS_DIR)
+	$(RMDIR) $(LOCAL_OBJ_DIR)
+	-rmdir --ignore-fail-on-non-empty $(BISECT_DIR)
 
 dirs: $(MORE_DIRS)
 
@@ -281,7 +293,7 @@ $(MORE_DIRS):
 # @param 7: target filename
 # @param 8: extra compiler flags
 define FPIC_COMPILE_RULE
-$2: $1 Makefile custom.mk | $(LOCAL_OBJ_DIR)
+$2: $1 Makefile custom.mk | $(FPIC_DIR)
 	if [ -f "$3" ]; then \
 	  ln -s "../../$(strip 3)" "$(strip $2)"; \
 	else \
@@ -297,7 +309,7 @@ endef
 $(foreach s,$(SOURCE),\
   $(eval $(call FPIC_COMPILE_RULE,\
     $s,\
-    $(LOCAL_OBJ_DIR)/$(notdir $s)_gt_fPIC.o,\
+    $(FPIC_DIR)/$(notdir $s)_gt_fPIC.o,\
 		$(GT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
     $(GT_CXX),\
     $(GT_OPTL),\
@@ -320,7 +332,7 @@ $(foreach s,$(SOURCE),\
 $(foreach s,$(SOURCE),\
   $(eval $(call FPIC_COMPILE_RULE,\
     $s,\
-    $(LOCAL_OBJ_DIR)/$(notdir $s)_fPIC.o,\
+    $(FPIC_DIR)/$(notdir $s)_fPIC.o,\
 		$(BISECT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
     $(TROUBLE_CXX),\
     $(TROUBLE_OPTL),\
@@ -328,7 +340,7 @@ $(foreach s,$(SOURCE),\
     bisect-default-out,\
     $(TROUBLE_CXXFLAGS))))
 
-# The fPIC variant built in OBJ_DIR instead of LOCAL_OBJ_DIR
+# The fPIC variant built in OBJ_DIR instead of FPIC_DIR
 $(foreach s,$(SOURCE),\
   $(eval $(call COMPILE_RULE,\
     $s,\
@@ -346,34 +358,34 @@ $(foreach s,$(SOURCE),\
 #     'Example01.cpp')
 define SPLIT_RULE
 
-$$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(LOCAL_OBJ_DIR)/$1_gt_fPIC.o
-$$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(LOCAL_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt
-$$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: $$(MAKEFILE)
-$$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o: | $$(LOCAL_OBJ_DIR)
-	if [ -s "$$(LOCAL_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt" ]; then \
+$$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o: $$(FPIC_DIR)/$1_gt_fPIC.o
+$$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o: $$(SYMBOLS_DIR)/$1_trouble_symbols_$$(NUMBER).txt
+$$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o: $$(MAKEFILE)
+$$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o: | $$(SPLIT_DIR)
+	if [ -s "$$(SYMBOLS_DIR)/$1_trouble_symbols_$$(NUMBER).txt" ]; then \
 	  objcopy \
-	    --weaken-symbols=$$(LOCAL_OBJ_DIR)/$1_trouble_symbols_$$(NUMBER).txt \
-	    $$(LOCAL_OBJ_DIR)/$1_gt_fPIC.o \
-	    $$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o; \
+	    --weaken-symbols=$$(SYMBOLS_DIR)/$1_trouble_symbols_$$(NUMBER).txt \
+	    $$(FPIC_DIR)/$1_gt_fPIC.o \
+	    $$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o; \
 	else \
 	  cp \
-	    $$(LOCAL_OBJ_DIR)/$1_gt_fPIC.o \
-	    $$(LOCAL_OBJ_DIR)/$1_gt_split_$$(NUMBER).o; \
+	    $$(FPIC_DIR)/$1_gt_fPIC.o \
+	    $$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o; \
 	fi
 
-$$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(LOCAL_OBJ_DIR)/$1_fPIC.o
-$$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(MAKEFILE)
-$$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: $$(LOCAL_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt
-$$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o: | $$(LOCAL_OBJ_DIR)
-	if [ -s "$$(LOCAL_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt" ]; then \
+$$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o: $$(FPIC_DIR)/$1_fPIC.o
+$$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o: $$(MAKEFILE)
+$$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o: $$(SYMBOLS_DIR)/$1_gt_symbols_$$(NUMBER).txt
+$$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o: | $$(SPLIT_DIR)
+	if [ -s "$$(SYMBOLS_DIR)/$1_gt_symbols_$$(NUMBER).txt" ]; then \
 	  objcopy \
-	    --weaken-symbols=$$(LOCAL_OBJ_DIR)/$1_gt_symbols_$$(NUMBER).txt \
-	    $$(LOCAL_OBJ_DIR)/$1_fPIC.o \
-	    $$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o; \
+	    --weaken-symbols=$$(SYMBOLS_DIR)/$1_gt_symbols_$$(NUMBER).txt \
+	    $$(FPIC_DIR)/$1_fPIC.o \
+	    $$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o; \
 	else \
 	  cp \
-	    $$(LOCAL_OBJ_DIR)/$1_fPIC.o \
-	    $$(LOCAL_OBJ_DIR)/$1_trouble_split_$$(NUMBER).o; \
+	    $$(FPIC_DIR)/$1_fPIC.o \
+	    $$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o; \
 	fi
 
 endef

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -373,7 +373,7 @@ $$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o: $$(FPIC_DIR)/$1_gt_fPIC.o
 $$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o: $$(SYMBOLS_DIR)/$1_trouble_symbols_$$(NUMBER).txt
 $$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o: $$(MAKEFILE)
 $$(SPLIT_DIR)/$1_gt_split_$$(NUMBER).o: | $$(SPLIT_DIR)
-  @$$(call color_out,CYAN,  $$(SPLIT_DIR)/$1_gt_fPIC.o -> $1_gt_split_$$(NUMBER).o)
+	@$$(call color_out,CYAN,  $$(SPLIT_DIR)/$1_gt_fPIC.o -> $1_gt_split_$$(NUMBER).o)
 	if [ -s "$$(SYMBOLS_DIR)/$1_trouble_symbols_$$(NUMBER).txt" ]; then \
 	  objcopy \
 	    --weaken-symbols=$$(SYMBOLS_DIR)/$1_trouble_symbols_$$(NUMBER).txt \
@@ -389,7 +389,7 @@ $$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o: $$(FPIC_DIR)/$1_fPIC.o
 $$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o: $$(MAKEFILE)
 $$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o: $$(SYMBOLS_DIR)/$1_gt_symbols_$$(NUMBER).txt
 $$(SPLIT_DIR)/$1_trouble_split_$$(NUMBER).o: | $$(SPLIT_DIR)
-  @$$(call color_out,CYAN,  $$(SPLIT_DIR)/$1_fPIC.o -> $1_trouble_split_$$(NUMBER).o)
+	@$$(call color_out,CYAN,  $$(SPLIT_DIR)/$1_fPIC.o -> $1_trouble_split_$$(NUMBER).o)
 	if [ -s "$$(SYMBOLS_DIR)/$1_gt_symbols_$$(NUMBER).txt" ]; then \
 	  objcopy \
 	    --weaken-symbols=$$(SYMBOLS_DIR)/$1_gt_symbols_$$(NUMBER).txt \

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -267,7 +267,7 @@ bisect-distclean: bisect-clean
 dirs: $(MORE_DIRS)
 
 $(MORE_DIRS):
-	mkdir -p $@
+	+mkdir -p $@
 
 # Copied mostly from Makefile.in COMPILE_RULE, but customized for bisect
 # Compiles a single object file with -fPIC, checking first for a precompiled

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -321,7 +321,7 @@ $(foreach s,$(SOURCE),\
   $(eval $(call FPIC_COMPILE_RULE,\
     $s,\
     $(FPIC_DIR)/$(notdir $s)_gt_fPIC.o,\
-		$(GT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
+    $(GT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
     $(GT_CXX),\
     $(GT_OPTL),\
     $(GT_SWITCHES),\
@@ -344,7 +344,7 @@ $(foreach s,$(SOURCE),\
   $(eval $(call FPIC_COMPILE_RULE,\
     $s,\
     $(FPIC_DIR)/$(notdir $s)_fPIC.o,\
-		$(BISECT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
+    $(BISECT_OBJ_DIR)/$(notdir $s)_fPIC.o,\
     $(TROUBLE_CXX),\
     $(TROUBLE_OPTL),\
     $(TROUBLE_SWITCHES),\

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -288,7 +288,7 @@ dirs: $(MORE_DIRS)
 $(MORE_DIRS):
 	@$(call color_out_noline,CYAN,  mkdir)
 	@echo " $@"
-	mkdir -p $@
+	+mkdir -p $@
 
 # Copied mostly from Makefile.in COMPILE_RULE, but customized for bisect
 # Compiles a single object file with -fPIC, checking first for a precompiled

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -285,7 +285,7 @@ def create_bisect_makefile(directory, replacements, gt_src,
         else:
             break
 
-    repl_copy['makefile'] = makepath
+    repl_copy['makefile'] = os.path.realpath(makepath)
     repl_copy['number'] = '{0:02d}'.format(num)
     logging.info('Creating makefile: %s', makepath)
     util.process_in_file(
@@ -497,8 +497,7 @@ def update_gt_results(directory, verbose=False,
 
     @return None
     '''
-    gt_resultfile = util.extract_make_var(
-        'GT_OUT', os.path.join(directory, 'Makefile'))[0]
+    gt_resultfile = util.extract_make_var('GT_OUT', directory=directory)[0]
     logging.info('Updating ground-truth results - %s', gt_resultfile)
     print('Updating ground-truth results -', gt_resultfile, end='', flush=True)
     run_make(
@@ -1221,7 +1220,7 @@ def test_makefile(args, makepath, testing_list, indent='  '):
         if args.delete:
             build_bisect(relmakepath, args.directory, verbose=args.verbose,
                          jobs=args.jobs, target='bisect-smallclean')
-    resultfile = util.extract_make_var('BISECT_RESULT', makepath,
+    resultfile = util.extract_make_var('BISECT_RESULT', relmakepath,
                                        args.directory)[0]
     resultpath = os.path.join(args.directory, resultfile)
     result = get_comparison_result(resultpath)
@@ -1656,8 +1655,7 @@ def run_bisect(arguments, prog=sys.argv[0]):
     logging.debug('  trouble hash:               "%s"', trouble_hash)
 
     # get the list of source files from the Makefile
-    sources = util.extract_make_var('SOURCE', 'Makefile',
-                                    directory=args.directory)
+    sources = util.extract_make_var('SOURCE', directory=args.directory)
     logging.debug('Sources')
     for source in sources:
         logging.debug('  %s', source)

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -294,17 +294,18 @@ def create_bisect_makefile(directory, replacements, gt_src,
         repl_copy,
         overwrite=True)
 
-    # Create the obj directory
+    # Create the obj/symbols directory
     if len(split_symbol_map) > 0:
-        try:
-            os.mkdir(os.path.join(directory, 'obj'))
-        except FileExistsError:
-            pass # ignore if the directory already exists
+        for subdir in ('obj', os.path.join('obj', 'symbols')):
+            try:
+                os.mkdir(os.path.join(directory, subdir))
+            except FileExistsError:
+                pass # ignore if the directory already exists
 
     # Create the txt files containing symbol lists within the obj directory
     for split_srcfile, split_symbols in split_symbol_map.items():
         split_basename = os.path.basename(split_srcfile)
-        split_base = os.path.join(directory, 'obj', split_basename)
+        split_base = os.path.join(directory, 'obj', 'symbols', split_basename)
         trouble_symbols_fname = split_base + '_trouble_symbols_' \
                 + repl_copy['number'] + '.txt'
         gt_symbols_fname = split_base + '_gt_symbols_' \

--- a/tests/flit_cli/flit_bisect/tst_bisect.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect.py
@@ -112,7 +112,7 @@ and run FLiT bisect
 ...     with open(os.path.join(temp_dir, 'custom.mk'), 'a') as mkout:
 ...         _ = mkout.write('SOURCE += tests/file4.cxx\\n')
 ...     with StringIO() as ostream:
-...         retval = th.flit.main(['bisect', '-C', temp_dir,
+...         retval = th.flit.main(['bisect', '-C', os.path.relpath(temp_dir),
 ...                                '--compiler-type', 'gcc',
 ...                                '--precision', 'double',
 ...                                'g++ -O3', 'BisectTest'],

--- a/tests/flit_cli/flit_bisect/tst_bisect_autosqlite_clang.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect_autosqlite_clang.py
@@ -147,6 +147,11 @@ and run FLiT bisect
 ...         '--no-print-directory', '--always-make',
 ...         '-f', os.path.join('bisect-precompile', 'bisect-make-01.mk')])
 ...     makeout2 = makeout2.strip().decode('utf-8').splitlines()
+...     makeout3 = subp.check_output([
+...         'make', '-C', temp_dir, '--dry-run', 'bisect-smallclean',
+...         '--no-print-directory', '--always-make',
+...         '-f', os.path.join('bisect-precompile', 'bisect-make-01.mk')])
+...     makeout3 = makeout3.strip().decode('utf-8').splitlines()
 ...     troublecxx = util.extract_make_var(
 ...         'TROUBLE_CXX',
 ...         os.path.join('bisect-precompile', 'bisect-make-01.mk'),
@@ -185,6 +190,15 @@ See that the generated Makefile for fake_clang34.py shows the correct type
 ['./fake_clang34.py']
 >>> troublecxx_type
 ['clang']
+
+>>> 'rm -rf bisect-precompile/obj/split' in makeout3
+True
+>>> 'rm -rf bisect-precompile/obj/symbols' not in makeout3
+True
+>>> 'rm -rf bisect-precompile/obj/fpic' not in makeout3
+True
+>>> 'rm -rf bisect-precompile/obj' not in makeout3
+True
 '''
 
 # Test setup before the docstring is run.

--- a/tests/flit_cli/flit_bisect/tst_bisect_biggest.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect_biggest.py
@@ -149,8 +149,9 @@ tst_bisect.py.
 ...     assert verbose == False
 ...     # Get the files being tested out of the makepath, and the BISECT_RESULT
 ...     # variable, and generate the expected results.
-...     sources = util.extract_make_var('TROUBLE_SRC', makepath)
-...     symbol_files = util.extract_make_var('TROUBLE_SYMBOLS', makepath)
+...     sources = util.extract_make_var('TROUBLE_SRC', makepath, directory)
+...     symbol_files = util.extract_make_var('TROUBLE_SYMBOLS', makepath,
+...                                          directory)
 ...     symbols = []
 ...     if symbol_files:
 ...         with open(os.path.join(directory, symbol_files[0]), 'r') as fin:
@@ -158,7 +159,8 @@ tst_bisect.py.
 ...     source_score = sum([all_file_scores[x] for x in sources])
 ...     symbol_score = sum([score for symbol, score in all_symbol_scores.items()
 ...                         if symbol.symbol in symbols])
-...     result_file = util.extract_make_var('BISECT_RESULT', makepath)[0]
+...     result_file = util.extract_make_var('BISECT_RESULT', makepath,
+...                                         directory)[0]
 ...     with open(os.path.join(directory, result_file), 'w') as rout:
 ...         rout.write('comparison\\n')
 ...         rout.write('{}\\n'.format(source_score + symbol_score))


### PR DESCRIPTION
Fixes #283 

**Description:**
FLiT Bisect with the `--delete` flag calls `make bisect-smallclean` on the bisect Makefile.  This was deleting the `bisect-XX/obj` directory, including the compiled fPIC objects.  To solve this, I

- split up the `obj/` directory into three subdirectories: `obj/fpic`, `obj/symbols`, and `obj/split`
- `obj/split` is deleted with `bisect-smallclean`
- `obj/fpic` is deleted with `bisect-clean`
- `obj/symbols` is deleted with `bisect-distclean`

**Documentation:**
No documentation changed.  The bisect directory structure is not found in the documentation.

**Tests:**
I added a test for `bisect-smallclean` in `tests/flit_cli/tst_bisect_autosqlite_clang.py` that sees if the `obj/` directory does not get deleted and that `obj/fpic` does not get deleted.