### PR TITLE
Issue286 add string helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,9 @@ matrix:
           packages:
             - *native_deps
 
-before_install: pip3 install --user toml $extra_pip
+before_install:
+  - pip3 install --user setuptools
+  - pip3 install --user toml $extra_pip
 
 script: make -j4 && make -j4 -C tests && make check
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -9,6 +9,7 @@
 * [FLiT Configuration File](flit-configuration-file.md)
     * [Available Compiler Flags](available-compiler-flags.md)
 * [Writing Test Cases](writing-test-cases.md)
+    * [FLiT Helpers](flit-helpers.md)
     * [MPI Support](mpi-support.md)
     * [CUDA Support](cuda-support.md)
     * [Run Wrapper and HPC Support](run-wrapper-and-hpc-support.md)

--- a/documentation/flit-helpers.md
+++ b/documentation/flit-helpers.md
@@ -1,0 +1,591 @@
+# FLiT Helpers
+
+[Prev](writing-test-cases.md)
+|
+[Table of Contents](README.md)
+|
+[Next](mpi-support.md)
+
+The FLiT library has a number of utility functionality that may be useful to
+those writing tests.
+
+- [CSV Reader and Writer](#csv-reader-and-writer)
+- [Info Stream](#info-stream)
+- [File System Utilities](#file-system-utilities)
+- [Subprocess Utilities](#subprocess-utilities)
+- [Miscellaneous](#miscellaneous)
+
+## CSV Reader and Writer
+
+FLiT provides two classes for reading and writing CSV files, `flit::CsvReader`
+and `flit::CsvWriter`.  These classes are used within FLiT to create the test
+result files, but are usable by users.
+
+The details can be seen in the FLiT source tree in `src/FlitCsv.h` and
+`src/FlitCsv.cpp`.  Here, we give example usage of these classes.
+
+
+### `flit::CsvRow`
+
+This is the basis of the usage with `flit::CsvReader`.  This class derives from
+`std::vector<std::string>` so you can use any function defined on that
+interface.
+
+Additionally, this class provides
+
+- `flit::CsvRow::header()` returning the `CsvRow` instance that represents the
+  header row.
+- `flit::CsvRow::setHeader()`: sets the header row
+- `flit::CsvRow::operator[](std::string)`: allowing you to index based on the
+  column header name.
+
+
+### `flit::CsvReader`
+
+Reads in from a stream and returns instances of `CsvRow` (which derive from
+`std::vector<std::string>`).  Here is an example of its usage:
+
+```c++
+std::istringstream input(
+  "#,Cost,Description\n"
+  "1,-3,Candy bar\n"
+  "2,-5,Garage parking\n"
+  "3,315,Got paid!\n"
+  );
+Flit::CsvReader reader(input);
+int balance = 0;
+for (flit::CsvRow row; reader >> row;) {
+  balance += std::stoi(row["Cost"]);
+  // could also do
+  // balance += std::stoi(row[1]);
+}
+assert(balance == 307);
+```
+
+There are other functions not demonstrated in this example:
+
+- `flit::CsvReader::header()`: returns a `CsvRow` containing the header row
+- `flit::CsvReader::stream()`: returns the stream that was passed in and is
+  being used
+- casting `flit::CsvReader` to a `bool` evaluates to `false` if there are no
+  more rows to parse and evaluates to `true` otherwise.
+
+
+### `flit::CsvWriter`
+
+Writes to a stream in CSV format.  Here is an example of its usage:
+
+```c++
+std::ofstream out("output.csv");
+flit::CsvWriter writer(out);
+
+std::vector<std::vector<double>> data {
+  {1.0, 2.0, 3.3},
+  {2.0, 2.0, 5.2},
+  {3.0, 2.5, 7.7},
+};
+
+writer << "x" << "y" << "z";
+writer.new_row();          // start a new row
+writer << data[0][0]
+       << data[0][1]
+       << data[0][2];
+writer.new_row();          // start a new row
+writer.write_row(data[1]); // write the whole row all at once
+writer.write_row(data[2]); // write the whole row all at once
+```
+
+Supported types with `operator<<()` are
+
+- `int`
+- `long`
+- `long long`
+- `unsigned int`
+- `unsigned long`
+- `unsigned long long`
+- `unsigned __int128`
+- `float`
+- `double`
+- `long double`
+- `std::string`
+
+To implement your own types, you will need to convert to one of these types.
+The `std::string` type will probably be the most common route.
+
+## Info Stream
+
+FLiT provides a way to output debugging information from tests that will only be printed when the `--verbose` flag is given to the compiled FLiT tests.  This is through a singleton object called `flit::info_stream`.  This object is an instance of the `flit::InfoStream` class that derives from `std::ostream`, so any object that can be printed to `std::ostream` can be printed with `flit::info_stream`.  This stream is thread-safe.
+
+Here is an example usage from within a test:
+
+```c++
+virtual flit::Variant run_impl(const std::vector<T>& ti) override {
+  auto &info = flit::info_stream;
+  info << id << ": beginning test\n";
+
+  // test implementation ...
+
+  info << id << ": ending test\n";
+  info << id << ": returned value = " << retval << "\n";
+  return retval;
+}
+```
+
+This class has a few more methods of interest:
+
+- `flit::InfoStream::show()`: turns on the debugging messages.  This is the
+  same as calling the tests with the `--verbose` flag.  Note: each thread has
+  their own local copy of `flit::info_stream`, so this would only affect the
+  current thread.
+- `flit::InfoStream::hide()`: the opposite of `show()`
+- `flit::InfoStream::flushout()`: flushes the stream
+
+
+## File System Utilities
+
+It is common to work with files within tests, so many of these functionalities
+are made easier if desired.  These are defined in `src/fsutil.h` and
+`src/fsutil.cpp`.
+
+
+### `flit::ifopen()` and `flit::ofopen()`
+
+Open files for in and out with error checking.  By default, if you open a file
+with `std::ifstream` and the file does not exist, or you open a file with
+`std::ofstream` with permission errors, then the default behavior is to
+silently ignore those errors.  Since that is not too useful to a programmer,
+these utility functions open the files with error checking turned on.
+
+```c++
+std::ifstream in;
+flit::ifopen(in, "in-file.txt"); // will throw a std::ios::failure if it fails
+
+std::ofstream out;
+flit::ofopen(out, "out-file.txt"); // will throw if it fails
+```
+
+Also, the `flit::ofopen()` function sets the precision of the `std::ofstream`
+to a very high number to ensure outputting does not cause floating-point
+truncation.
+
+
+### `flit::join()`
+
+Joins two parts of a path together.  Currently, the only supported separator is
+the Unix one, "/", but if Windows is supported in the future, this function
+would join path elements properly.
+
+Note, you can pass in as many arguments to this function as you want.
+
+```c++
+auto full_path = flit::join("/home", "user", "git", "FLiT", "src", "fsutil.h");
+```
+
+
+### `flit::readfile()`
+
+Reads the entire content of the given filename into a `std::string`.
+
+```c++
+std::string contents = flit::readfile(flit::join("data", "setup.txt"));
+```
+
+
+### `flit::listdir()`
+
+Lists the contents of a directory into a `std::vector<std::string>`.
+
+```c++
+auto listing = flit::listdir(".");
+```
+
+
+### `flit::printdir()`
+
+Prints the contents of a directory to the console.
+
+```c++
+flit::printdir("."); // prints all files and folders in the current directory
+```
+
+
+### `flit::touch()`
+
+Creates an empty file if it doesn't exist, or update the modification time if
+it does exist.  Similar to the `touch` command-line utility.
+
+```c++
+flit::touch("empty.txt"); // create a new empty file
+```
+
+
+### `flit::mkdir()`
+
+Make a directory (optionally with a unix permission mode).  Throws an exception on failure (`std::ios_base::failure`).
+
+```c++
+flit::mkdir(flit::join("output", "directory"), 0777);
+```
+
+The above will attempt to make the directory "output/directory" with read,
+write, and execute permissions for all.
+
+
+### `flit::rmdir()`
+
+Remove an empty directory.  Throws a `std::ios_base::failure` exception on
+failure (which will happen if the directory is not empty, you do not have
+permission to delete it, or it doesn't exist).
+
+```c++
+flit::rmdir(flit::join("output", "directory"));
+```
+
+
+### `flit::rec_rmdir()`
+
+Recursively delete everything under a particular directory.  This is the same
+as `rm -rf <directory>` in the console.  Throws a `std::ios_base::failure`
+exception upon failure (mostly for permission issues).
+
+```c++
+using flit::join;
+flit::mkdir("output");
+flit::mkdir(join("output", "directory"));
+flit::touch(join("output", "directory", "file1.txt"));
+flit::touch(join("output", "file2.txt"));
+flit::rec_rmdir("output"); // delete it all
+```
+
+
+### `flit::curdir()`
+
+Simply returns the absolute path to the current working directory.
+
+```c++
+auto current_path = flit::curdir();
+```
+
+
+### `flit::chdir()`
+
+Change the to given directory (i.e. `cd` on the command-line)
+
+```c++
+auto prev_path = flit::curdir();
+flit::mkdir("output");
+flit::chdir("output");
+// do some work in output
+flit::chdir(prev_path);
+```
+
+
+### `flit::which()`
+
+Finds the given filename from a list of paths (given as a colon-separated
+list).  If the path is not given, then the `PATH` environment variable is used.
+
+```c++
+auto system_echo = flit::which("echo");
+auto my_echo = flit::which("echo",
+                           "/home/user/bin:/home/user/sys/bin:/opt/bin");
+```
+
+The first one uses the system `PATH` variable for lookup (returning the same
+thing as `which echo` from the command-line).  The second is given a
+user-specified path string with colon separated search paths.
+
+If no such file is found, then `std::ios_base::failure` is thrown.
+
+
+### `flit::realpath()`
+
+Returns the cononical absolute path after resolving symbolic links of the given
+path.  The given path need not exist.  For those elements that do exist and are
+symbolic links, they are resolved.
+
+```c++
+auto absolute = flit::realpath(os.path.join(".", "output", "..", "output",
+                                            "test.txt"));
+```
+
+This will resolve as expected.
+
+
+### Class `TempDir`
+
+An RAII-style class that creates a temporary directory.  When the class goes
+out of scope (i.e., is deleted), then the directory, along with all of its
+contents, are deleted.
+
+```c++
+{
+  flit::TempDir tmpdir;
+  flit::mkdir(flit::join(tmpdir.name(), "data"));
+  std::ofstream out;
+  flit::ofopen(out, flit::join(tmpdir.name(), "data", "output.txt"));
+  // output to out
+  // do some work ...
+}
+// when we go out of scope, tmpdir and its contents will be deleted
+```
+
+
+### Class `TempFile`
+
+An RAII-style class that creates a temporary file.  When the class goes out of
+scope (i.e., is deleted), then teh file is deleted.  Optionally, you can give a
+directory where to create the temporary file.
+
+```c++
+{
+  flit::TempDir tmpdir;
+  flit::TempFile tmpfile(tmpdir.name());
+  tmpfile.out << "hello there";
+  std::cout << "Created " << tmpfile.name << std::endl;
+}
+```
+
+
+### Class `PushDir`
+
+An RAII-style class that calls `flit::chdir()` in the constructor to the given
+directory, and calls `flit::chdir()` back to the directory it was in before.
+You can also query what the previous directory was.
+
+```c++
+{
+  flit::TempDir temporaryDirectory;
+  flit::PushDir pusher(temporaryDirectory.name());
+  // now in the temporary directory
+  // do some work ...
+}
+// first pusher goes out of scope and we cd out of temporaryDirectory
+// then temporaryDirectory goes out of scope and the directory is deleted
+```
+
+
+### Class `FileCloser`
+
+An RAII-style class for handling the closing of a `FILE*` pointer (created
+using the `std::fopen()`-family of functions).  When this class goes out of scope,
+it will close the `FILE*` pointer, preventing resource leaks in the case of
+exceptions or programmer negligence.
+
+```c++
+{
+  flit::FileCloser handler(std::fopen("hello.txt", "w"));
+  fprintf(handler.file, "Value: %02f\n", 3.14159);
+}
+```
+
+Also gives access to the integer `fd` file descriptor.  This can be useful as
+shown in the next section with the `FdReplace` class.
+
+
+### Class `FdReplace`
+
+An RAII-style class for replacing the file descriptor of one `FILE*` handle
+with the file descriptor of another `FILE*` handle.  When this object goes out
+of scope and is deleted, then the original file descriptor is restored.
+
+An example usage of this is to capture output that would go to stdout.  If you
+use `std::cout`, then there are ways to redirect that output to a stream buffer
+for another stream, such as a `std::stringstream` and capture it that way.  But
+what about code that calls `printf()` and other functions that act on the
+`stdout` or `stderr` global pointers?  Here is a trick to grab that output.
+And it seems most implementations of `std::cout` end up feeding into the
+`stdout` pointer, so capturing it here gets all of it.
+
+```c++
+{
+  flit::FileCloser stdout_handler(std::fopen("stdout-captured.txt", "w"));
+  flit::FdReplace stdout_capturer(stdout, stdout_handler.file);
+  printf("hello world!\n"); // will print instead to "stdout-captured.txt"
+  std::cout << "hello world!\n"; // will also be captured
+}
+// stdout is now restored
+```
+
+
+### Class `StreamBufReplace`
+
+An RAII-style class for replacing stream buffers.  Suppose you do not want your
+function to output to `std::cout` during the test, but at runtime, you do.  In
+your test, you can capture the output using this class, and restore it at the
+end of your test.
+
+```c++
+{
+  std::ostringstream capturer;
+  flit::StreamBufReplace replacer(std::cout, capturer);
+  std::cout << "hello world!\n"; // will be captured by capturer
+  capturer.str(); // will contain "hello world!\n"
+}
+// std::cout is now restored
+std::cout << "hello again\n"; // will be printed to the screen
+```
+
+
+## Subprocess Utilities
+
+Many tests may wish to call subprocesses.  There are already utilities such as
+the `system()` call.  These are a little hard to use, especially if you want to
+capture the standard output of the child process.  Fortunately, FLiT has some
+useful helper functions for you.
+
+These utilities are defined in `src/subprocess.h` and `src/subprocess.cpp`.
+
+
+### `flit::call_with_output()`
+
+Calls a command as though from the command-line and returns a
+`flit::ProcResult` struct containing the returncode, stdout, and stderr of the
+child process.
+
+```c++
+auto result = flit::call_with_output("curl localhost:8000/data.html");
+
+if (result.ret != 0) {
+  throw std::logic_failure("curl command failed");
+}
+
+flit::info_stream << "curl stdout:\n" << result.out << "\n\n"
+                  << "curl stderr:\n" << result.err << "\n\n";
+```
+
+
+### Calling and Registering a Main Function
+
+This topic is also covered in
+[Writing Test Cases](writing-test-cases.md#wrapping-around-a-main-function).
+
+It is often the case that you want to test your application as a whole.  That
+means calling and testing your `main()` function directly.  Here is an example
+to illustrate how to use the functions declared in `src/subprocess.h` to run a
+`main()` function.
+
+```c++
+#include <flit.h>
+
+#define main my_main
+#include "main.cc"
+#undef main
+FLIT_REGISTER_MAIN(my_main)
+
+template <typename T>
+class MainTest : public flit::TestBase<T> {
+   ...
+};
+REGISTER_TYPE(MainTest);
+
+template<>
+flit::Variant MainTest<double> run_impl(const std::vector<double> &ti) {
+  FLIT_UNUSED(ti);
+  auto results = flit::call_main(my_main, "myapp", "--input data/file.txt");
+  std::vector<std::string> vec_results;
+  if (results.ret != 0) {
+    throw std::logic_error("my_main() failed in its execution");
+  }
+  vec_results.emplace_back(std::move(results.out));
+  vec_results.emplace_back(std::move(results.err));
+  return vec_results;
+}
+```
+
+More detail is given in
+[Writing Test Cases](writing-test-cases.md#wrapping-around-a-main-function).
+But, here we will highlight a few points.  First, the file containing the user-defined `main()` function is in `main.cc`, which is included into the test file after the `#define main my_main`.  That trick renames the name `main` to `my_main`.  It no longer name clashes, our app still has only one `main()`, and we can call `my_main()` as a normal function now.  After including that source file, we call `FLIT_REGISTER_MAIN()` on the newly named `my_main()` function for later.
+
+In our test, we call `flit::call_main()`.  In it we give three parameters:
+
+1. the function pointer to the `main`-like function.  This function pointer
+   needs to be registered with `FLIT_REGISTER_MAIN()`.  This is so that FLiT
+   can call this function in a child process.
+2. the value of `argv[0]` when `my_main()` is called (in a child process).
+   Some programs change their behavior when the name of the executable changes
+   (for example, `bash` behaves different if the name of the executable is
+   `sh`).
+3. the rest of the command-line parameters as would be given on the bash
+   prompt.
+
+Afterwards, the standard output and standard error are placed into a vector and
+returned.  It will be the job of the user's `compare()` function that will make
+sense of the standard output and standard error when doing the comparison
+between two runs.
+
+Similarly, there is a function called `call_mpi_main()` that has a very similar
+interface to `call_main()`.  The only difference is that an extra argument is
+inserted as the second argument.  This extra argument is the command (with
+arguments) for the `mpirun` executable.  Not only can you choose which `mpirun`
+you want to use (or if you want to use `srun` or abuse this function to call a
+different wrapper than has nothing to do with MPI), but you can specify the
+arguments to `mpirun` such as the number of processes to
+create.
+
+
+## Miscellaneous
+
+There are many other helper functions that may be useful to test writers.
+Those are documented here, along with where they are implemented.
+
+### `flit::split()` (in `src/flitHelpers.h`)
+
+Split a string by a delimiter.  This is similar to python's `split()` function.
+
+```c++
+auto split_by_space = flit::split("my name is Mike", ' ');
+for (auto &item : split_by_space) {
+  std::cout << "'" << item << "'" << std::endl;
+}
+```
+
+This will print
+
+```
+'my'
+'name'
+'is'
+'Mike'
+```
+
+There is an optional parameter of `maxsplit` which specifies how many times to
+split maximum.
+
+```c++
+auto split_only_twice = flit::split("flit::CsvReader::operator<<()", ':', 2);
+for (auto &item : split_only_twice) {
+  std::cout << "'" << item << "'" << std::endl;
+}
+```
+
+This will print
+
+```
+'flit'
+''
+'CsvReader::operator<<()'
+```
+
+### `flit::rtrim()`, `flit::ltrim()`, and `flit::trim()` (in `src/flitHelpers.h`)
+
+All three of these functions return new strings so that the original is not
+modified.  This is to prevent unintended consequences in code.
+
+- `flit::rtrim()`: trims whitespace from the right-hand side of a string
+- `flit::ltrim()`: trims whitespace from the left-hand side of a string
+- `flit::trim()`: trims whitespace from both the left and right
+
+### `flit::l2norm()` (in `src/flitHelpers.h`)
+
+Computes the L2 norm between two `std::vector<T>` instances.  The type of `T`
+must implement minus and multiply between themselves, and they must implement
+plus with a `long double` accumulator.  This is intended for floating-point
+types, but users can use custom types if they choose.
+
+[Prev](writing-test-cases.md)
+|
+[Table of Contents](README.md)
+|
+[Next](mpi-support.md)
+

--- a/documentation/mpi-support.md
+++ b/documentation/mpi-support.md
@@ -1,6 +1,6 @@
 # MPI Support
 
-[Prev](writing-test-cases.md)
+[Prev](flit-helpers.md)
 |
 [Table of Contents](README.md)
 |
@@ -118,7 +118,7 @@ MPI_Send(...);
 ```
 
 
-[Prev](writing-test-cases.md)
+[Prev](flit-helpers.md)
 |
 [Table of Contents](README.md)
 |

--- a/documentation/writing-test-cases.md
+++ b/documentation/writing-test-cases.md
@@ -4,7 +4,7 @@
 |
 [Table of Contents](README.md)
 |
-[Next](mpi-support.md)
+[Next](flit-helpers.md)
 
 When you initialize a test directory using `flit init`, a test file called
 `Empty.cpp` will be placed in the `tests` directory.  This test is as the name
@@ -518,4 +518,4 @@ For more examples, look in `FLiT/tests/flit_mpi/data`.
 |
 [Table of Contents](README.md)
 |
-[Next](mpi-support.md)
+[Next](flit-helpers.md)

--- a/litmus-tests/tests/SimpleCHull.cpp
+++ b/litmus-tests/tests/SimpleCHull.cpp
@@ -360,7 +360,7 @@ protected:
     FLIT_UNUSED(ti);
 
     // write inputs to a temporary file
-    flit::fsutil::TempFile tmpfile;
+    flit::TempFile tmpfile;
     std::vector<float> towrite(ti.begin(), ti.end());
     auto writer = fopen(tmpfile.name.c_str(), "w+");
     fwrite(towrite.data(), sizeof(float), towrite.size(), writer);

--- a/src/TestBase.h
+++ b/src/TestBase.h
@@ -91,6 +91,7 @@
 #include "Variant.h"
 #include "flitHelpers.h"
 #include "timeFunction.h"
+#include "fsutil.h"
 
 #include <fstream>
 #include <functional>

--- a/src/flit.cpp
+++ b/src/flit.cpp
@@ -206,7 +206,7 @@ FlitOptions parseArguments(int argCount, char const* const* argList) {
   // TODO- be in PATH or in the current directory, or it may already be an
   // TODO- absolute path.
   if (argCount > 0) {
-    g_program_path = fsutil::which(argList[0]);
+    g_program_path = flit::which(argList[0]);
   }
 
   std::vector<std::string> helpOpts          = { "-h", "--help" };

--- a/src/flit.h
+++ b/src/flit.h
@@ -382,8 +382,8 @@ long double runComparison_impl(TestFactory* factory, const TestResult &gt,
       throw std::invalid_argument("baseline comparison type is not None when"
                                   " the resultfile is defined");
     }
-    Variant gtval = Variant::fromString(fsutil::readfile(gt.resultfile()));
-    Variant resval = Variant::fromString(fsutil::readfile(res.resultfile()));
+    Variant gtval = Variant::fromString(flit::readfile(gt.resultfile()));
+    Variant resval = Variant::fromString(flit::readfile(res.resultfile()));
     return test->variant_compare(gtval, resval);
   }
   return test->variant_compare(gt.result(), res.result());

--- a/src/flitHelpers.h
+++ b/src/flitHelpers.h
@@ -116,8 +116,7 @@ extern thread_local InfoStream info_stream;
 std::ostream& operator<<(std::ostream&, const unsigned __int128);
 unsigned __int128 stouint128(const std::string &str);
 
-inline
-std::vector<std::string> split(
+inline std::vector<std::string> split(
     const std::string &tosplit, char delimiter,
     std::size_t maxsplit=std::numeric_limits<std::size_t>::max())
 {
@@ -133,6 +132,32 @@ std::vector<std::string> split(
     pieces.emplace_back(remaining.str());
   }
   return pieces;
+}
+
+inline std::string rtrim(const std::string &text) {
+  auto right_iter = std::find_if_not(text.rbegin(), text.rend(),
+      [](unsigned char c) { return std::isspace(c); });
+  auto len = std::distance(right_iter, text.rend());
+  return text.substr(0, len);
+}
+
+inline std::string ltrim(const std::string &text) {
+  auto left_iter = std::find_if_not(text.begin(), text.end(),
+      [](unsigned char c) { return std::isspace(c); });
+  return std::string(left_iter, text.end());
+}
+
+inline std::string trim(const std::string &text) {
+  // could implement as
+  //   return rtrim(ltrim(text))
+  // but that creates more string copies than necessary
+  auto left_iter = std::find_if_not(text.begin(), text.end(),
+      [](unsigned char c) { return std::isspace(c); });
+  auto right_iter = std::find_if_not(text.rbegin(), text.rend(),
+      [](unsigned char c) { return std::isspace(c); });
+  auto left = std::distance(text.begin(), left_iter);
+  auto right = std::distance(right_iter, text.rend());
+  return text.substr(left, right - left);
 }
 
 template <typename F, typename I>

--- a/src/flitHelpers.h
+++ b/src/flitHelpers.h
@@ -236,49 +236,6 @@ long double l2norm(const std::vector<T> &v1, const std::vector<T> &v2) {
   return score;
 }
 
-/** Opens a file, but on failure, throws std::ios::failure
- *
- * T must be one of {fstream, ifstream, ofstream}
- *
- * The passed in filestream should be an empty-constructed stream
- */
-template <typename T>
-void _openfile_check(T& filestream, const std::string &filename) {
-  // turn on exceptions on failure
-  filestream.exceptions(std::ios::failbit);
-
-  // opening will throw if the file does not exist or is not readable
-  filestream.open(filename);
-
-  // turn off all exceptions (back to the default behavior)
-  filestream.exceptions(std::ios::goodbit);
-}
-
-/** Opens a file for reading, but on failure, throws std::ios::failure
- *
- * The passed in filestream should be an empty-constructed stream
- *
- * Note: This was changed to pass in the stream rather than return it because
- * GCC 4.8 failed to compile - it failed to use the move assignment operator
- * and move constructor, and instead tried to use the copy constructor.
- */
-inline void ifopen(std::ifstream& in, const std::string &filename) {
-  _openfile_check<std::ifstream>(in, filename);
-}
-
-/** Opens a file for writing, but on failure, throws std::ios::failure
- *
- * The passed in filestream should be an empty-constructed stream
- *
- * Note: this was changed to pass in the stream rather than return it because
- * GCC 4.8 failed to compile - it failed to use the move assignment operator
- * and move constructor, and instead tried to use the copy constructor.
- */
-inline void ofopen(std::ofstream& out, const std::string &filename) {
-  _openfile_check<std::ofstream>(out, filename);
-  out.precision(1000);  // lots of digits of precision
-}
-
 } // end of namespace flit
 
 #endif // FLIT_HELPERS_HPP

--- a/src/flitHelpers.h
+++ b/src/flitHelpers.h
@@ -116,6 +116,7 @@ extern thread_local InfoStream info_stream;
 std::ostream& operator<<(std::ostream&, const unsigned __int128);
 unsigned __int128 stouint128(const std::string &str);
 
+/// Split text by a delimiter
 inline std::vector<std::string> split(
     const std::string &tosplit, char delimiter,
     std::size_t maxsplit=std::numeric_limits<std::size_t>::max())
@@ -134,6 +135,7 @@ inline std::vector<std::string> split(
   return pieces;
 }
 
+/// Trim whitespace off of the end of the text
 inline std::string rtrim(const std::string &text) {
   auto right_iter = std::find_if_not(text.rbegin(), text.rend(),
       [](unsigned char c) { return std::isspace(c); });
@@ -141,12 +143,14 @@ inline std::string rtrim(const std::string &text) {
   return text.substr(0, len);
 }
 
+/// Trim whitespace off of the beginning of the text
 inline std::string ltrim(const std::string &text) {
   auto left_iter = std::find_if_not(text.begin(), text.end(),
       [](unsigned char c) { return std::isspace(c); });
   return std::string(left_iter, text.end());
 }
 
+/// Trim whitespace off of the beginning and end of the text
 inline std::string trim(const std::string &text) {
   // could implement as
   //   return rtrim(ltrim(text))

--- a/src/flitHelpers.h
+++ b/src/flitHelpers.h
@@ -117,11 +117,21 @@ std::ostream& operator<<(std::ostream&, const unsigned __int128);
 unsigned __int128 stouint128(const std::string &str);
 
 inline
-std::vector<std::string> split(const std::string &tosplit, char delimiter) {
+std::vector<std::string> split(
+    const std::string &tosplit, char delimiter,
+    std::size_t maxsplit=std::numeric_limits<std::size_t>::max())
+{
   std::vector<std::string> pieces;
   std::string piece;
   std::istringstream stream(tosplit);
-  while (std::getline(stream, piece, delimiter)) { pieces.emplace_back(piece); }
+  while (pieces.size() < maxsplit && std::getline(stream, piece, delimiter)) {
+    pieces.emplace_back(piece);
+  }
+  if (stream) {
+    std::ostringstream remaining;
+    remaining << stream.rdbuf();
+    pieces.emplace_back(remaining.str());
+  }
   return pieces;
 }
 

--- a/src/fsutil.cpp
+++ b/src/fsutil.cpp
@@ -108,7 +108,6 @@
 #include <memory>
 
 namespace flit {
-namespace fsutil {
 
 std::string readfile(FILE* file) {
   fseek(file, 0, SEEK_END);
@@ -138,7 +137,7 @@ void rec_rmdir(const std::string &directory) {
     }
   }
   // now remove the directory
-  ::flit::fsutil::rmdir(directory);
+  ::flit::rmdir(directory);
 }
 
 void mkdir(const std::string &directory, int mode) {
@@ -329,5 +328,4 @@ FdReplace::~FdReplace() {
   dup2(old_fd_copy, old_fd);
 }
 
-} // end of namespace fsutil
 } // end of namespace flit

--- a/src/subprocess.cpp
+++ b/src/subprocess.cpp
@@ -36,7 +36,7 @@ flit::ProcResult call_main_impl(
 namespace flit {
 
 ProcResult call_with_output(const std::string &command) {
-  fsutil::TempFile tempfile;
+  flit::TempFile tempfile;
 
   // run the command
   std::string cmd = command + " 2>" + tempfile.name;
@@ -56,7 +56,7 @@ ProcResult call_with_output(const std::string &command) {
 
   // wait and grab the return code
   int ret = pclose(output);
-  auto err = fsutil::readfile(tempfile.name);
+  auto err = flit::readfile(tempfile.name);
 
   if (WIFEXITED(ret)) {
     ret = WEXITSTATUS(ret);

--- a/tests/flit_mpi/data/MpiFloat.cpp
+++ b/tests/flit_mpi/data/MpiFloat.cpp
@@ -202,7 +202,7 @@ protected:
   virtual flit::Variant run_impl(const std::vector<T> &ti) override {
     FLIT_UNUSED(ti);
     auto main_func = get_mpi_main<T>();
-    flit::fsutil::TempDir tempdir;      // create a temp dir
+    flit::TempDir tempdir;      // create a temp dir
     flit::ProcResult result;
 
     // change to a different directory when calling main
@@ -211,15 +211,15 @@ protected:
     // This trick is nice because it now makes this test reentrant since each
     // invocation will executed from a separate directory.
     {
-      flit::fsutil::PushDir pushd(tempdir.name());  // go to it
+      flit::PushDir pushd(tempdir.name());  // go to it
       auto result = flit::call_mpi_main(main_func, "mpirun -n 2", "mympi",
                                         "remaining arguments");
     }
 
-    auto logcontents_0 = flit::fsutil::readfile(
-        flit::fsutil::join(tempdir.name(), "out-0.log"));
-    auto logcontents_1 = flit::fsutil::readfile(
-        flit::fsutil::join(tempdir.name(), "out-1.log"));
+    auto logcontents_0 = flit::readfile(
+        flit::join(tempdir.name(), "out-0.log"));
+    auto logcontents_1 = flit::readfile(
+        flit::join(tempdir.name(), "out-1.log"));
 
     std::vector<std::string> vec_result;
     vec_result.emplace_back(std::to_string(result.ret));

--- a/tests/flit_src/tst_TestBase.cpp
+++ b/tests/flit_src/tst_TestBase.cpp
@@ -92,9 +92,6 @@
 
 #include <sstream>
 
-// move namespace flit::fsutil into namespace fsutil
-namespace fsutil { using namespace flit::fsutil; }
-
 namespace {
 
 std::ostream& operator<<(std::ostream& out, std::vector<std::string> vec) {
@@ -619,20 +616,20 @@ void tst_TestBase_run_outputFileUsingFilebase() {
   test.to_return = std::vector<double> { 1, 2, 3 };
 
   std::vector<double> ti {};
-  fsutil::TempDir tmpdir;
-  auto filebase = fsutil::join(tmpdir.name(), "my-file-base");
+  flit::TempDir tmpdir;
+  auto filebase = flit::join(tmpdir.name(), "my-file-base");
   bool shouldTime = false;
   auto results = test.run(ti, filebase, shouldTime);
   TH_EQUAL(results.size(), 1);
   TH_EQUAL(results[0].result(), flit::Variant());
 
-  auto dir_contents = fsutil::listdir(tmpdir.name());
+  auto dir_contents = flit::listdir(tmpdir.name());
   std::string filename = "my-file-base_This-is-my-ID_d.dat";
   TH_VERIFY(std::any_of(dir_contents.begin(), dir_contents.end(),
             [&filename] (std::string fname) {
               return fname == filename;
             }));
-  auto contents = fsutil::readfile(fsutil::join(tmpdir.name(), filename));
+  auto contents = flit::readfile(flit::join(tmpdir.name(), filename));
   auto read_results = flit::Variant::fromString(contents);
   TH_EQUAL(flit::Variant(test.to_return), read_results);
 }
@@ -648,16 +645,16 @@ void tst_TestBase_run_outputVariantsToFile() {
     test.to_return = to_return;
 
     std::vector<double> ti {};
-    fsutil::TempDir tmpdir;
-    auto filebase = fsutil::join(tmpdir.name(), "my-file-base");
+    flit::TempDir tmpdir;
+    auto filebase = flit::join(tmpdir.name(), "my-file-base");
     bool shouldTime = false;
     auto results = test.run(ti, filebase, shouldTime);
     TH_EQUAL(results.size(), 1);
     TH_EQUAL(results[0].result(), flit::Variant());
 
-    auto dir_contents = fsutil::listdir(tmpdir.name());
+    auto dir_contents = flit::listdir(tmpdir.name());
     std::string filename = "my-file-base_This-is-my-ID_d.dat";
-    auto contents = fsutil::readfile(fsutil::join(tmpdir.name(), filename));
+    auto contents = flit::readfile(flit::join(tmpdir.name(), filename));
     auto read_results = flit::Variant::fromString(contents);
     TH_EQUAL(flit::Variant(test.to_return), read_results);
   };

--- a/tests/flit_src/tst_flitHelpers_h.cpp
+++ b/tests/flit_src/tst_flitHelpers_h.cpp
@@ -104,6 +104,21 @@ unsigned __int128 combine_to_128(uint64_t left_half, uint64_t right_half) {
   return val;
 }
 
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::vector<T> &vec) {
+  out << "[";
+  bool first = true;
+  for (auto &val : vec) {
+    if (!first) {
+      out << ", ";
+    }
+    first = false;
+    out << val;
+  }
+  out << "]";
+  return out;
+}
+
 } // end of unnamed namespace
 
 void tst_as_float_32bit() {
@@ -276,3 +291,63 @@ void tst_l2norm() {
   TH_EQUAL(flit::l2norm(two_elems, two_elems),  0.0L );
 }
 TH_REGISTER(tst_l2norm);
+
+void tst_split_empty() {
+  TH_EQUAL(flit::split("", '\n'), std::vector<std::string>{});
+}
+TH_REGISTER(tst_split_empty);
+
+void tst_split_nonempty() {
+  std::string text("hello");
+  auto actual = flit::split(text, ' ');
+  std::vector<std::string> expected {text};
+  TH_EQUAL(actual, expected);
+}
+TH_REGISTER(tst_split_nonempty);
+
+void tst_split_one_split() {
+  std::string text = "hello there";
+  std::vector<std::string> expected_split = { "hello", "there" };
+  TH_EQUAL(flit::split(text, ' '), expected_split);
+}
+TH_REGISTER(tst_split_one_split);
+
+void tst_split_many_splits() {
+  std::string text = "hello there my friend";
+  std::vector<std::string> expected_split {"hello", "there", "my", "friend"};
+  TH_EQUAL(flit::split(text, ' '), expected_split);
+  expected_split = {
+    "h",
+    "llo th",
+    "r",
+    " my fri",
+    "nd",
+  };
+  TH_EQUAL(flit::split(text, 'e'), expected_split);
+}
+TH_REGISTER(tst_split_many_splits);
+
+void tst_split_maxsplit_zero() {
+  std::string text = "hello there my friend";
+  std::vector<std::string> expected_split { "hello there my friend" };
+  TH_EQUAL(flit::split(text, ' ', 0), expected_split);
+}
+TH_REGISTER(tst_split_maxsplit_zero);
+
+void tst_split_maxsplit_one() {
+  std::string text = "hello there my friend";
+  std::vector<std::string> expected_split { "hello", "there my friend" };
+  TH_EQUAL(flit::split(text, ' ', 1), expected_split);
+}
+TH_REGISTER(tst_split_maxsplit_one);
+
+void tst_split_maxsplit_many() {
+  std::string text = "hello there my friend";
+  std::vector<std::string> expected_split { "hello", "there", "my", "friend" };
+  TH_EQUAL(flit::split(text, ' ', 100), expected_split);
+  TH_EQUAL(flit::split(text, ' ', 3), expected_split);
+
+  expected_split = { "hello", "there", "my friend" };
+  TH_EQUAL(flit::split(text, ' ', 2), expected_split);
+}
+TH_REGISTER(tst_split_maxsplit_many);

--- a/tests/flit_src/tst_flitHelpers_h.cpp
+++ b/tests/flit_src/tst_flitHelpers_h.cpp
@@ -121,6 +121,8 @@ std::ostream& operator<<(std::ostream& out, const std::vector<T> &vec) {
 
 } // end of unnamed namespace
 
+namespace tst_as_float {
+
 void tst_as_float_32bit() {
   uint32_t val = 1067316150;
   float expected = 1.234;
@@ -197,6 +199,10 @@ void tst_as_float_80bit() {
   TH_EQUAL(flit::as_float(val), expected);
 }
 TH_REGISTER(tst_as_float_80bit);
+
+} // end of namespace tst_as_float
+
+namespace tst_as_int {
 
 void tst_as_int_32bit() {
   uint32_t expected = 1067316150;
@@ -275,6 +281,8 @@ void tst_as_int_128bit() {
 }
 TH_REGISTER(tst_as_int_128bit);
 
+} // end of namespace tst_as_int
+
 void tst_l2norm() {
   std::vector<float> empty;
   std::vector<float> one_elem { 1.0L };
@@ -291,6 +299,8 @@ void tst_l2norm() {
   TH_EQUAL(flit::l2norm(two_elems, two_elems),  0.0L );
 }
 TH_REGISTER(tst_l2norm);
+
+namespace tst_split {
 
 void tst_split_empty() {
   TH_EQUAL(flit::split("", '\n'), std::vector<std::string>{});
@@ -351,3 +361,181 @@ void tst_split_maxsplit_many() {
   TH_EQUAL(flit::split(text, ' ', 2), expected_split);
 }
 TH_REGISTER(tst_split_maxsplit_many);
+
+} // end of namespace tst_split
+
+namespace tst_trim {
+
+TH_TEST(tst_trim_empty) {
+  TH_EQUAL(flit::trim(""), "");
+}
+
+TH_TEST(tst_trim_nothing_to_trim) {
+  TH_EQUAL(flit::trim("hello"), "hello");
+}
+
+TH_TEST(tst_trim_left_spaces) {
+  TH_EQUAL(flit::trim("  monty"), "monty");
+}
+
+TH_TEST(tst_trim_right_spaces) {
+  TH_EQUAL(flit::trim("python  "), "python");
+}
+
+TH_TEST(tst_trim_leftright_spaces) {
+  TH_EQUAL(flit::trim("  ROCKS!!  "), "ROCKS!!");
+}
+
+TH_TEST(tst_trim_tabs) {
+  TH_EQUAL(flit::trim("\ttabs-suck!\t\t"), "tabs-suck!");
+}
+
+TH_TEST(tst_trim_newlines) {
+  TH_EQUAL(flit::trim("\nmike-is-cool\n\n"), "mike-is-cool");
+}
+
+TH_TEST(tst_trim_formfeed) {
+  TH_EQUAL(flit::trim("\f\fwho-uses-form-feeds?\f\f\f"),
+           "who-uses-form-feeds?");
+}
+
+TH_TEST(tst_trim_carriagereturn) {
+  TH_EQUAL(flit::trim("\r\rwho-uses-carriage-returns?\r\r"),
+           "who-uses-carriage-returns?");
+}
+
+TH_TEST(tst_trim_verticaltab) {
+  TH_EQUAL(flit::trim("\v\vvertical-tabs?--really?\v\v"),
+           "vertical-tabs?--really?");
+}
+
+TH_TEST(tst_trim_alltypes) {
+  TH_EQUAL(flit::trim(" \t\n\f\r\vall-types \t\f\n\v\r"),
+           "all-types");
+}
+
+TH_TEST(tst_trim_onlywhitespace) {
+  TH_EQUAL(flit::trim("  \t\n \f \r\v \r   \t\n \n"), "");
+}
+
+TH_TEST(tst_trim_whitespace_inside) {
+  TH_EQUAL(flit::trim(" whitespace\tis\ninside of this\rphrase\n  "),
+           "whitespace\tis\ninside of this\rphrase");
+}
+
+TH_TEST(tst_ltrim_empty) {
+  TH_EQUAL(flit::ltrim(""), "");
+}
+
+TH_TEST(tst_ltrim_nothing_to_ltrim) {
+  TH_EQUAL(flit::ltrim("hello"), "hello");
+}
+
+TH_TEST(tst_ltrim_left_spaces) {
+  TH_EQUAL(flit::ltrim("  monty"), "monty");
+}
+
+TH_TEST(tst_ltrim_right_spaces) {
+  TH_EQUAL(flit::ltrim("python  "), "python  ");
+}
+
+TH_TEST(tst_ltrim_leftright_spaces) {
+  TH_EQUAL(flit::ltrim("  ROCKS!!  "), "ROCKS!!  ");
+}
+
+TH_TEST(tst_ltrim_tabs) {
+  TH_EQUAL(flit::ltrim("\ttabs-suck!\t\t"), "tabs-suck!\t\t");
+}
+
+TH_TEST(tst_ltrim_newlines) {
+  TH_EQUAL(flit::ltrim("\nmike-is-cool\n\n"), "mike-is-cool\n\n");
+}
+
+TH_TEST(tst_ltrim_formfeed) {
+  TH_EQUAL(flit::ltrim("\f\fwho-uses-form-feeds?\f\f\f"),
+           "who-uses-form-feeds?\f\f\f");
+}
+
+TH_TEST(tst_ltrim_carriagereturn) {
+  TH_EQUAL(flit::ltrim("\r\rwho-uses-carriage-returns?\r\r"),
+           "who-uses-carriage-returns?\r\r");
+}
+
+TH_TEST(tst_ltrim_verticaltab) {
+  TH_EQUAL(flit::ltrim("\v\vvertical-tabs?--really?\v\v"),
+           "vertical-tabs?--really?\v\v");
+}
+
+TH_TEST(tst_ltrim_alltypes) {
+  TH_EQUAL(flit::ltrim(" \t\n\f\r\vall-types \t\f\n\v\r"),
+           "all-types \t\f\n\v\r");
+}
+
+TH_TEST(tst_ltrim_onlywhitespace) {
+  TH_EQUAL(flit::ltrim("  \t\n \f \r\v \r   \t\n \n"), "");
+}
+
+TH_TEST(tst_ltrim_whitespace_inside) {
+  TH_EQUAL(flit::ltrim(" whitespace\tis\ninside of this\rphrase\n  "),
+           "whitespace\tis\ninside of this\rphrase\n  ");
+}
+
+TH_TEST(tst_rtrim_empty) {
+  TH_EQUAL(flit::rtrim(""), "");
+}
+
+TH_TEST(tst_rtrim_nothing_to_rtrim) {
+  TH_EQUAL(flit::rtrim("hello"), "hello");
+}
+
+TH_TEST(tst_rtrim_left_spaces) {
+  TH_EQUAL(flit::rtrim("  monty"), "  monty");
+}
+
+TH_TEST(tst_rtrim_right_spaces) {
+  TH_EQUAL(flit::rtrim("python  "), "python");
+}
+
+TH_TEST(tst_rtrim_leftright_spaces) {
+  TH_EQUAL(flit::rtrim("  ROCKS!!  "), "  ROCKS!!");
+}
+
+TH_TEST(tst_rtrim_tabs) {
+  TH_EQUAL(flit::rtrim("\ttabs-suck!\t\t"), "\ttabs-suck!");
+}
+
+TH_TEST(tst_rtrim_newlines) {
+  TH_EQUAL(flit::rtrim("\nmike-is-cool\n\n"), "\nmike-is-cool");
+}
+
+TH_TEST(tst_rtrim_formfeed) {
+  TH_EQUAL(flit::rtrim("\f\fwho-uses-form-feeds?\f\f\f"),
+           "\f\fwho-uses-form-feeds?");
+}
+
+TH_TEST(tst_rtrim_carriagereturn) {
+  TH_EQUAL(flit::rtrim("\r\rwho-uses-carriage-returns?\r\r"),
+           "\r\rwho-uses-carriage-returns?");
+}
+
+TH_TEST(tst_rtrim_verticaltab) {
+  TH_EQUAL(flit::rtrim("\v\vvertical-tabs?--really?\v\v"),
+           "\v\vvertical-tabs?--really?");
+}
+
+TH_TEST(tst_rtrim_alltypes) {
+  TH_EQUAL(flit::rtrim(" \t\n\f\r\vall-types \t\f\n\v\r"),
+           " \t\n\f\r\vall-types");
+}
+
+TH_TEST(tst_rtrim_onlywhitespace) {
+  TH_EQUAL(flit::rtrim("  \t\n \f \r\v \r   \t\n \n"), "");
+}
+
+TH_TEST(tst_rtrim_whitespace_inside) {
+  TH_EQUAL(flit::rtrim(" whitespace\tis\ninside of this\rphrase\n  "),
+           " whitespace\tis\ninside of this\rphrase");
+}
+
+
+} // end of namespace tst_trim

--- a/tests/flit_src/tst_flitHelpers_h.cpp
+++ b/tests/flit_src/tst_flitHelpers_h.cpp
@@ -537,5 +537,4 @@ TH_TEST(tst_rtrim_whitespace_inside) {
            " whitespace\tis\ninside of this\rphrase");
 }
 
-
 } // end of namespace tst_trim

--- a/tests/flit_src/tst_flit_cpp.cpp
+++ b/tests/flit_src/tst_flit_cpp.cpp
@@ -98,7 +98,7 @@
 
 #include <cstdio>
 
-using flit::fsutil::TempFile;
+using flit::TempFile;
 
 namespace {
 
@@ -466,7 +466,7 @@ void tst_parseArguments_set_progpath() {
   std::vector<const char*> argList = {progpath};
   flit::g_program_path = "";
   flit::parseArguments(argList.size(), argList.data());
-  TH_EQUAL(flit::fsutil::which(progpath), flit::g_program_path);
+  TH_EQUAL(flit::which(progpath), flit::g_program_path);
 }
 TH_REGISTER(tst_parseArguments_set_progpath);
 

--- a/tests/flit_src/tst_fsutil.cpp
+++ b/tests/flit_src/tst_fsutil.cpp
@@ -88,11 +88,6 @@
 #include <algorithm>
 #include <memory>
 
-namespace fsutil {
-  // import all fsutil names into this new namespace
-  using namespace ::flit::fsutil;
-} // end of namespace fsutil
-
 namespace {
 
 bool string_startswith(const std::string main, const std::string needle) {
@@ -140,7 +135,7 @@ std::vector<std::string> splitlines(const std::string &tosplit) {
 void verify_listdir(const std::string &dir,
                     std::vector<std::string> expected)
 {
-  auto listing = fsutil::listdir(dir);
+  auto listing = flit::listdir(dir);
   std::sort(listing.begin(), listing.end());
   std::sort(expected.begin(), expected.end());
   TH_EQUAL(expected, listing);
@@ -186,17 +181,17 @@ void tst_splitlines() {
 TH_REGISTER(tst_splitlines);
 
 void tst_verify_listdir_exists() {
-  fsutil::TempDir tempdir;
+  flit::TempDir tempdir;
 
   // check that this fails
   TH_THROWS(verify_listdir(tempdir.name(), {"hello"}), th::AssertionError);
 
   verify_listdir(tempdir.name(), {});
 
-  fsutil::touch(fsutil::join(tempdir.name(), "hello"));
+  flit::touch(flit::join(tempdir.name(), "hello"));
   verify_listdir(tempdir.name(), {"hello"});
 
-  fsutil::touch(fsutil::join(tempdir.name(), "apple of my eye"));
+  flit::touch(flit::join(tempdir.name(), "apple of my eye"));
   verify_listdir(tempdir.name(), {"hello", "apple of my eye"});
 }
 TH_REGISTER(tst_verify_listdir_exists);
@@ -242,44 +237,44 @@ namespace tst_functions {
 
 void tst_join() {
   TH_EQUAL("path/to/my/object/file with spaces.txt",
-           fsutil::join("path/to/my/object/file with spaces.txt"));
+           flit::join("path/to/my/object/file with spaces.txt"));
   TH_EQUAL("path/to/my/object/file with spaces.txt",
-           fsutil::join("path/to/my/object", "file with spaces.txt"));
+           flit::join("path/to/my/object", "file with spaces.txt"));
   TH_EQUAL("path/to/my/object/file with spaces.txt",
-           fsutil::join("path/to", "my/object", "file with spaces.txt"));
+           flit::join("path/to", "my/object", "file with spaces.txt"));
   TH_EQUAL("path/to/my/object/file with spaces.txt",
-           fsutil::join("path/to", "my", "object", "file with spaces.txt"));
+           flit::join("path/to", "my", "object", "file with spaces.txt"));
   TH_EQUAL("path/to/my/object/file with spaces.txt",
-           fsutil::join("path", "to", "my", "object", "file with spaces.txt"));
+           flit::join("path", "to", "my", "object", "file with spaces.txt"));
 }
 TH_REGISTER(tst_join);
 
 void tst_readfile_filename() {
-  fsutil::TempFile f;
+  flit::TempFile f;
   std::string content = "My string value";
   f.out << content;
   f.out.flush();
-  TH_EQUAL(content, fsutil::readfile(f.name));
+  TH_EQUAL(content, flit::readfile(f.name));
 }
 TH_REGISTER(tst_readfile_filename);
 
 void tst_readfile_filename_doesnt_exist() {
-  TH_THROWS(fsutil::readfile("/does/not/exist.txt"), std::ios_base::failure);
+  TH_THROWS(flit::readfile("/does/not/exist.txt"), std::ios_base::failure);
 }
 TH_REGISTER(tst_readfile_filename_doesnt_exist);
 
 void tst_readfile_filepointer() {
-  fsutil::FileCloser temporary_file(tmpfile());
+  flit::FileCloser temporary_file(tmpfile());
   std::string content = "My string value";
   fprintf(temporary_file.file, "%s", content.c_str());
   fflush(temporary_file.file);
-  TH_EQUAL(content, fsutil::readfile(temporary_file.file));
+  TH_EQUAL(content, flit::readfile(temporary_file.file));
 }
 TH_REGISTER(tst_readfile_filepointer);
 
 void tst_listdir() {
-  fsutil::TempDir dir;
-  auto listing = fsutil::listdir(dir.name());
+  flit::TempDir dir;
+  auto listing = flit::listdir(dir.name());
   TH_EQUAL(std::vector<std::string> {}, listing);
 
   std::vector<std::string> expected_listing {
@@ -289,10 +284,10 @@ void tst_listdir() {
     "file4.txt",
   };
   for (auto &fname : expected_listing) {
-    fsutil::touch(fsutil::join(dir.name(), fname));
+    flit::touch(flit::join(dir.name(), fname));
   }
 
-  listing = fsutil::listdir(dir.name());
+  listing = flit::listdir(dir.name());
   std::sort(listing.begin(), listing.end());
 
   TH_EQUAL(expected_listing, listing);
@@ -307,10 +302,10 @@ void tst_printdir_exists() {
   {
     // capture standard out
     std::ostringstream captured;
-    fsutil::StreamBufReplace replacer(std::cout, captured);
+    flit::StreamBufReplace replacer(std::cout, captured);
 
     // call function under test
-    fsutil::printdir(directory);
+    flit::printdir(directory);
 
     // grab the output lines
     auto lines = splitlines(captured.str());
@@ -330,39 +325,39 @@ void tst_printdir_exists() {
   };
 
   // create a directory to list
-  fsutil::TempDir tempdir;
+  flit::TempDir tempdir;
   verify_printdir(tempdir.name(), { "./", "../" });
 
   // add some files to the directory
-  fsutil::touch(fsutil::join(tempdir.name(), "file1.txt"));
-  fsutil::touch(fsutil::join(tempdir.name(), "file2.txt"));
-  fsutil::touch(fsutil::join(tempdir.name(), "file3.txt"));
-  fsutil::touch(fsutil::join(tempdir.name(), "file4.txt"));
-  fsutil::mkdir(fsutil::join(tempdir.name(), "dir1"), 0700);
-  fsutil::mkdir(fsutil::join(tempdir.name(), "dir2"), 0700);
-  fsutil::touch(fsutil::join(tempdir.name(), "dir1", "myfile1.tex"));
-  fsutil::touch(fsutil::join(tempdir.name(), "dir1", "myfile2.tex"));
+  flit::touch(flit::join(tempdir.name(), "file1.txt"));
+  flit::touch(flit::join(tempdir.name(), "file2.txt"));
+  flit::touch(flit::join(tempdir.name(), "file3.txt"));
+  flit::touch(flit::join(tempdir.name(), "file4.txt"));
+  flit::mkdir(flit::join(tempdir.name(), "dir1"), 0700);
+  flit::mkdir(flit::join(tempdir.name(), "dir2"), 0700);
+  flit::touch(flit::join(tempdir.name(), "dir1", "myfile1.tex"));
+  flit::touch(flit::join(tempdir.name(), "dir1", "myfile2.tex"));
 
   verify_printdir(tempdir.name(),
                   {"./", "../", "file1.txt", "file2.txt", "file3.txt",
                    "file4.txt", "dir1/", "dir2/"});
-  verify_printdir(fsutil::join(tempdir.name(), "dir1"),
+  verify_printdir(flit::join(tempdir.name(), "dir1"),
                   {"./", "../", "myfile1.tex", "myfile2.tex"});
-  verify_printdir(fsutil::join(tempdir.name(), "dir2"), {"./", "../"});
+  verify_printdir(flit::join(tempdir.name(), "dir2"), {"./", "../"});
 }
 TH_REGISTER(tst_printdir_exists);
 
 void tst_printdir_doesnt_exist() {
-  TH_THROWS(fsutil::printdir("/dir/does/not/exist"), std::ios_base::failure);
+  TH_THROWS(flit::printdir("/dir/does/not/exist"), std::ios_base::failure);
 }
 TH_REGISTER(tst_printdir_doesnt_exist);
 
 void tst_rec_rmdir_exists() {
-  using fsutil::TempDir;
-  using fsutil::mkdir;
-  using fsutil::touch;
-  using fsutil::join;
-  using fsutil::rec_rmdir;
+  using flit::TempDir;
+  using flit::mkdir;
+  using flit::touch;
+  using flit::join;
+  using flit::rec_rmdir;
 
   // make a directory structure
   TempDir tempdir;
@@ -408,223 +403,223 @@ void tst_rec_rmdir_exists() {
 TH_REGISTER(tst_rec_rmdir_exists);
 
 void tst_rec_rmdir_doesnt_exist() {
-  TH_THROWS(fsutil::rec_rmdir("/dir/does/not/exist"), std::ios_base::failure);
+  TH_THROWS(flit::rec_rmdir("/dir/does/not/exist"), std::ios_base::failure);
 }
 TH_REGISTER(tst_rec_rmdir_doesnt_exist);
 
 void tst_rec_rmdir_on_file() {
-  fsutil::TempFile tmpfile;
-  TH_THROWS(fsutil::rec_rmdir(tmpfile.name), std::ios_base::failure);
+  flit::TempFile tmpfile;
+  TH_THROWS(flit::rec_rmdir(tmpfile.name), std::ios_base::failure);
 }
 TH_REGISTER(tst_rec_rmdir_on_file);
 
 void tst_mkdir() {
-  fsutil::TempDir tempdir;
+  flit::TempDir tempdir;
   verify_listdir(tempdir.name(), {});
-  fsutil::mkdir(fsutil::join(tempdir.name(), "dir1"));
+  flit::mkdir(flit::join(tempdir.name(), "dir1"));
   verify_listdir(tempdir.name(), {"dir1"});
-  verify_listdir(fsutil::join(tempdir.name(), "dir1"), {});
+  verify_listdir(flit::join(tempdir.name(), "dir1"), {});
 }
 TH_REGISTER(tst_mkdir);
 
 void tst_rmdir_empty() {
-  fsutil::TempDir tempdir;
-  fsutil::mkdir(fsutil::join(tempdir.name(), "dir1"));
+  flit::TempDir tempdir;
+  flit::mkdir(flit::join(tempdir.name(), "dir1"));
   verify_listdir(tempdir.name(), {"dir1"});
-  fsutil::rmdir(fsutil::join(tempdir.name(), "dir1"));
+  flit::rmdir(flit::join(tempdir.name(), "dir1"));
   verify_listdir(tempdir.name(), {});
 }
 TH_REGISTER(tst_rmdir_empty);
 
 void tst_rmdir_full() {
-  fsutil::TempDir tempdir;
-  fsutil::mkdir(fsutil::join(tempdir.name(), "dir1"));
-  fsutil::touch(fsutil::join(tempdir.name(), "dir1", "file.txt"));
+  flit::TempDir tempdir;
+  flit::mkdir(flit::join(tempdir.name(), "dir1"));
+  flit::touch(flit::join(tempdir.name(), "dir1", "file.txt"));
   verify_listdir(tempdir.name(), {"dir1"});
-  verify_listdir(fsutil::join(tempdir.name(), "dir1"), {"file.txt"});
-  TH_THROWS(fsutil::rmdir(fsutil::join(tempdir.name(), "dir1")),
+  verify_listdir(flit::join(tempdir.name(), "dir1"), {"file.txt"});
+  TH_THROWS(flit::rmdir(flit::join(tempdir.name(), "dir1")),
             std::ios_base::failure);
   verify_listdir(tempdir.name(), {"dir1"});
-  verify_listdir(fsutil::join(tempdir.name(), "dir1"), {"file.txt"});
+  verify_listdir(flit::join(tempdir.name(), "dir1"), {"file.txt"});
 }
 TH_REGISTER(tst_rmdir_full);
 
 void tst_rmdir_doesnt_exist() {
-  TH_THROWS(fsutil::rmdir("/does/not/exist"), std::ios_base::failure);
+  TH_THROWS(flit::rmdir("/does/not/exist"), std::ios_base::failure);
 }
 TH_REGISTER(tst_rmdir_doesnt_exist);
 
 void tst_curdir() {
-  fsutil::TempDir tempdir1;
-  fsutil::TempDir tempdir2;
-  auto originaldir = fsutil::curdir();
+  flit::TempDir tempdir1;
+  flit::TempDir tempdir2;
+  auto originaldir = flit::curdir();
   {
-    fsutil::PushDir pd1(tempdir1.name());
-    TH_EQUAL(tempdir1.name(), fsutil::curdir());
+    flit::PushDir pd1(tempdir1.name());
+    TH_EQUAL(tempdir1.name(), flit::curdir());
     {
-      fsutil::PushDir pd2(tempdir2.name());
-      TH_EQUAL(tempdir2.name(), fsutil::curdir());
+      flit::PushDir pd2(tempdir2.name());
+      TH_EQUAL(tempdir2.name(), flit::curdir());
     }
-    TH_EQUAL(tempdir1.name(), fsutil::curdir());
+    TH_EQUAL(tempdir1.name(), flit::curdir());
   }
-  TH_EQUAL(originaldir, fsutil::curdir());
+  TH_EQUAL(originaldir, flit::curdir());
 }
 TH_REGISTER(tst_curdir);
 
 void tst_chdir_exists() {
-  fsutil::TempDir tempdir;
-  auto originaldir = fsutil::curdir();
+  flit::TempDir tempdir;
+  auto originaldir = flit::curdir();
   try {
-    fsutil::chdir(tempdir.name());
-    TH_EQUAL(tempdir.name(), fsutil::curdir());
+    flit::chdir(tempdir.name());
+    TH_EQUAL(tempdir.name(), flit::curdir());
   } catch (...) {
-    fsutil::chdir(originaldir);
+    flit::chdir(originaldir);
     throw;
   }
-  fsutil::chdir(originaldir);
-  TH_EQUAL(originaldir, fsutil::curdir());
+  flit::chdir(originaldir);
+  TH_EQUAL(originaldir, flit::curdir());
 }
 TH_REGISTER(tst_chdir_exists);
 
 void tst_chdir_doesnt_exist() {
-  TH_THROWS(fsutil::chdir("/does/not/exist"), std::ios_base::failure);
+  TH_THROWS(flit::chdir("/does/not/exist"), std::ios_base::failure);
 }
 TH_REGISTER(tst_chdir_doesnt_exist);
 
 void tst_chdir_on_file() {
-  fsutil::TempFile tempfile;
-  TH_THROWS(fsutil::chdir(tempfile.name), std::ios_base::failure);
+  flit::TempFile tempfile;
+  TH_THROWS(flit::chdir(tempfile.name), std::ios_base::failure);
 }
 TH_REGISTER(tst_chdir_on_file);
 
 void tst_which_defaultpath_empty() {
-  TH_THROWS(fsutil::which(""), std::ios_base::failure);
+  TH_THROWS(flit::which(""), std::ios_base::failure);
 }
 TH_REGISTER(tst_which_defaultpath_empty);
 
 void tst_which_defaultpath_absolute() {
-  fsutil::TempDir tempdir;
-  TH_THROWS(fsutil::which(fsutil::join(tempdir.name(), "does/not/exist")),
+  flit::TempDir tempdir;
+  TH_THROWS(flit::which(flit::join(tempdir.name(), "does/not/exist")),
             std::ios_base::failure);
 
-  fsutil::TempFile tempfile;
-  TH_EQUAL(tempfile.name, fsutil::which(tempfile.name));
+  flit::TempFile tempfile;
+  TH_EQUAL(tempfile.name, flit::which(tempfile.name));
 
   // directory fails even if it exists
-  TH_THROWS(fsutil::which(tempdir.name()), std::ios_base::failure);
+  TH_THROWS(flit::which(tempdir.name()), std::ios_base::failure);
 }
 TH_REGISTER(tst_which_defaultpath_absolute);
 
 void tst_which_defaultpath_relative() {
-  fsutil::TempDir tempdir;
-  fsutil::PushDir pusher(tempdir.name());
+  flit::TempDir tempdir;
+  flit::PushDir pusher(tempdir.name());
 
-  TH_THROWS(fsutil::which("does/not/exist"), std::ios_base::failure);
+  TH_THROWS(flit::which("does/not/exist"), std::ios_base::failure);
 
-  fsutil::mkdir("does");
-  fsutil::touch("does/exist");
-  TH_EQUAL(fsutil::join(tempdir.name(), "does/exist"),
-           fsutil::which("does/exist"));
+  flit::mkdir("does");
+  flit::touch("does/exist");
+  TH_EQUAL(flit::join(tempdir.name(), "does/exist"),
+           flit::which("does/exist"));
 
   // in current directory
-  fsutil::touch("exists");
-  TH_EQUAL(fsutil::join(tempdir.name(), "exists"), fsutil::which("./exists"));
-  TH_THROWS(fsutil::which("exists"), std::ios_base::failure);
+  flit::touch("exists");
+  TH_EQUAL(flit::join(tempdir.name(), "exists"), flit::which("./exists"));
+  TH_THROWS(flit::which("exists"), std::ios_base::failure);
 
   // directory fails even if it exists
-  TH_THROWS(fsutil::which("./does"), std::ios_base::failure);
+  TH_THROWS(flit::which("./does"), std::ios_base::failure);
 }
 TH_REGISTER(tst_which_defaultpath_relative);
 
 void tst_which_defaultpath_tofind() {
-  fsutil::TempDir tempdir;
-  fsutil::PushDir pusher(tempdir.name());
+  flit::TempDir tempdir;
+  flit::PushDir pusher(tempdir.name());
 
-  TH_THROWS(fsutil::which("does-not-exist"), std::ios_base::failure);
+  TH_THROWS(flit::which("does-not-exist"), std::ios_base::failure);
 
   auto bash_path = trim(flit::call_with_output("which bash").out);
-  TH_EQUAL(bash_path, fsutil::which("bash"));
+  TH_EQUAL(bash_path, flit::which("bash"));
 }
 TH_REGISTER(tst_which_defaultpath_tofind);
 
 void tst_which_givenpath_empty() {
-  fsutil::TempDir path_piece1, path_piece2;
+  flit::TempDir path_piece1, path_piece2;
   auto path = path_piece1.name() + ":" + path_piece2.name();
 
-  TH_THROWS(fsutil::which("", path), std::ios_base::failure);
+  TH_THROWS(flit::which("", path), std::ios_base::failure);
 }
 TH_REGISTER(tst_which_givenpath_empty);
 
 void tst_which_givenpath_absolute() {
-  fsutil::TempDir path_piece1, path_piece2;
+  flit::TempDir path_piece1, path_piece2;
   auto path = path_piece1.name() + ":" + path_piece2.name();
 
-  fsutil::TempDir tempdir;
-  TH_THROWS(fsutil::which(fsutil::join(tempdir.name(), "does/not/exist"), path),
+  flit::TempDir tempdir;
+  TH_THROWS(flit::which(flit::join(tempdir.name(), "does/not/exist"), path),
             std::ios_base::failure);
 
-  fsutil::TempFile tempfile;
-  TH_EQUAL(tempfile.name, fsutil::which(tempfile.name, path));
+  flit::TempFile tempfile;
+  TH_EQUAL(tempfile.name, flit::which(tempfile.name, path));
 
   // directory fails even if it exists
-  TH_THROWS(fsutil::which(tempdir.name(), path), std::ios_base::failure);
+  TH_THROWS(flit::which(tempdir.name(), path), std::ios_base::failure);
 }
 TH_REGISTER(tst_which_givenpath_absolute);
 
 void tst_which_givenpath_relative() {
-  fsutil::TempDir path_piece1, path_piece2;
+  flit::TempDir path_piece1, path_piece2;
   auto path = path_piece1.name() + ":" + path_piece2.name();
 
-  fsutil::TempDir tempdir;
-  fsutil::PushDir pusher(tempdir.name());
+  flit::TempDir tempdir;
+  flit::PushDir pusher(tempdir.name());
 
-  TH_THROWS(fsutil::which("does/not/exist", path), std::ios_base::failure);
+  TH_THROWS(flit::which("does/not/exist", path), std::ios_base::failure);
 
-  fsutil::mkdir("does");
-  fsutil::touch("does/exist");
-  TH_EQUAL(fsutil::join(tempdir.name(), "does/exist"),
-           fsutil::which("does/exist", path));
+  flit::mkdir("does");
+  flit::touch("does/exist");
+  TH_EQUAL(flit::join(tempdir.name(), "does/exist"),
+           flit::which("does/exist", path));
 
   // in current directory
-  fsutil::touch("exists");
-  TH_EQUAL(fsutil::join(tempdir.name(), "exists"), fsutil::which("./exists", path));
-  TH_THROWS(fsutil::which("exists", path), std::ios_base::failure);
+  flit::touch("exists");
+  TH_EQUAL(flit::join(tempdir.name(), "exists"), flit::which("./exists", path));
+  TH_THROWS(flit::which("exists", path), std::ios_base::failure);
 
   // directory fails even if it exists
-  TH_THROWS(fsutil::which("./does", path), std::ios_base::failure);
+  TH_THROWS(flit::which("./does", path), std::ios_base::failure);
 }
 TH_REGISTER(tst_which_givenpath_relative);
 
 void tst_which_givenpath_tofind() {
-  fsutil::TempDir path_piece1, path_piece2;
+  flit::TempDir path_piece1, path_piece2;
   auto path = path_piece1.name() + ":" + path_piece2.name();
 
-  fsutil::TempDir tempdir;
-  fsutil::PushDir pusher(tempdir.name());
+  flit::TempDir tempdir;
+  flit::PushDir pusher(tempdir.name());
 
-  TH_THROWS(fsutil::which("does-not-exist", path), std::ios_base::failure);
+  TH_THROWS(flit::which("does-not-exist", path), std::ios_base::failure);
 
   std::string file1_name("first-file");
   std::string file2_name("second-file");
-  auto file1 = fsutil::join(path_piece1.name(), file1_name);
-  auto file2 = fsutil::join(path_piece2.name(), file2_name);
-  fsutil::touch(file1);
-  fsutil::touch(file2);
+  auto file1 = flit::join(path_piece1.name(), file1_name);
+  auto file2 = flit::join(path_piece2.name(), file2_name);
+  flit::touch(file1);
+  flit::touch(file2);
 
-  TH_EQUAL(file1, fsutil::which(file1_name, path));
-  TH_EQUAL(file2, fsutil::which(file2_name, path));
+  TH_EQUAL(file1, flit::which(file1_name, path));
+  TH_EQUAL(file2, flit::which(file2_name, path));
 
   // check that the first one is returned if there are duplicates
   path = ".:" + path;
-  fsutil::touch(file1_name);
-  TH_EQUAL(fsutil::join(tempdir.name(), file1_name),
-           fsutil::which(file1_name, path));
+  flit::touch(file1_name);
+  TH_EQUAL(flit::join(tempdir.name(), file1_name),
+           flit::which(file1_name, path));
 
   // check that directories do not match, even if they are duplicates
-  fsutil::mkdir(fsutil::join(path_piece1.name(), "mydirectory"));
-  TH_THROWS(fsutil::which("mydirectory", path), std::ios_base::failure);
-  fsutil::mkdir(fsutil::join(path_piece1.name(), file2_name));
-  TH_EQUAL(file2, fsutil::which(file2_name, path));
+  flit::mkdir(flit::join(path_piece1.name(), "mydirectory"));
+  TH_THROWS(flit::which("mydirectory", path), std::ios_base::failure);
+  flit::mkdir(flit::join(path_piece1.name(), file2_name));
+  TH_EQUAL(file2, flit::which(file2_name, path));
 }
 TH_REGISTER(tst_which_givenpath_tofind);
 
@@ -633,68 +628,68 @@ TH_REGISTER(tst_which_givenpath_tofind);
 namespace tst_PushDir {
 
 void tst_PushDir_constructor_existing_dir() {
-  fsutil::TempDir temp;
-  std::string curdir = fsutil::curdir();
-  fsutil::PushDir pd(temp.name());
+  flit::TempDir temp;
+  std::string curdir = flit::curdir();
+  flit::PushDir pd(temp.name());
   TH_EQUAL(curdir, pd.previous_dir());
-  TH_EQUAL(temp.name(), fsutil::curdir());
+  TH_EQUAL(temp.name(), flit::curdir());
 }
 TH_REGISTER(tst_PushDir_constructor_existing_dir);
 
 void tst_PushDir_constructor_missing_dir() {
-  TH_THROWS(fsutil::PushDir pd("/does/not/exist"), std::ios_base::failure);
+  TH_THROWS(flit::PushDir pd("/does/not/exist"), std::ios_base::failure);
 }
 TH_REGISTER(tst_PushDir_constructor_missing_dir);
 
 void tst_PushDir_destructor_existing_dir() {
-  fsutil::TempDir temp1;
-  fsutil::TempDir temp2;
-  auto curdir = fsutil::curdir();
+  flit::TempDir temp1;
+  flit::TempDir temp2;
+  auto curdir = flit::curdir();
   {
-    fsutil::PushDir pd1(temp1.name());
+    flit::PushDir pd1(temp1.name());
     TH_EQUAL(curdir, pd1.previous_dir());
     {
-      fsutil::PushDir pd2(temp2.name());
+      flit::PushDir pd2(temp2.name());
       TH_EQUAL(temp1.name(), pd2.previous_dir());
-      TH_EQUAL(temp2.name(), fsutil::curdir());
+      TH_EQUAL(temp2.name(), flit::curdir());
     }
-    TH_EQUAL(temp1.name(), fsutil::curdir());
+    TH_EQUAL(temp1.name(), flit::curdir());
   }
-  TH_EQUAL(curdir, fsutil::curdir());
+  TH_EQUAL(curdir, flit::curdir());
 }
 TH_REGISTER(tst_PushDir_destructor_existing_dir);
 
 void tst_PushDir_destructor_missing_dir() {
-  auto curdir = fsutil::curdir();
+  auto curdir = flit::curdir();
   std::ostringstream captured;
   // capture stderr and assert on its output
-  fsutil::StreamBufReplace buffer_replacer(std::cerr, captured);
+  flit::StreamBufReplace buffer_replacer(std::cerr, captured);
   {
-    fsutil::TempDir temp2;
-    std::unique_ptr<fsutil::PushDir> pd1;
+    flit::TempDir temp2;
+    std::unique_ptr<flit::PushDir> pd1;
     {
-      std::unique_ptr<fsutil::PushDir> pd2;
+      std::unique_ptr<flit::PushDir> pd2;
       {
-        fsutil::TempDir temp1;
+        flit::TempDir temp1;
 
-        pd1.reset(new fsutil::PushDir(temp1.name()));
+        pd1.reset(new flit::PushDir(temp1.name()));
         TH_EQUAL(curdir, pd1->previous_dir());
-        TH_EQUAL(temp1.name(), fsutil::curdir());
+        TH_EQUAL(temp1.name(), flit::curdir());
 
-        pd2.reset(new fsutil::PushDir(temp2.name()));
+        pd2.reset(new flit::PushDir(temp2.name()));
         TH_EQUAL(temp1.name(), pd2->previous_dir());
-        TH_EQUAL(temp2.name(), fsutil::curdir());
+        TH_EQUAL(temp2.name(), flit::curdir());
       } // deletes temp1
-      TH_EQUAL(temp2.name(), fsutil::curdir());
+      TH_EQUAL(temp2.name(), flit::curdir());
       TH_EQUAL("", captured.str());
     } // deletes pd2, with temp1.name() not existing
     // should be unable to go to temp1.name() since it doesn't exist
     // but no exception since it is from a destructor
     TH_VERIFY(string_startswith(captured.str(),
                                 "ios_base error: Could not change directory"));
-    TH_EQUAL(temp2.name(), fsutil::curdir());
+    TH_EQUAL(temp2.name(), flit::curdir());
   } // deletes pd1 and temp2
-  TH_EQUAL(curdir, fsutil::curdir());
+  TH_EQUAL(curdir, flit::curdir());
   // make sure there is at most one newline and it is at the end
   TH_VERIFY(captured.str().find('\n') == captured.str().size() - 1);
 }
@@ -708,14 +703,14 @@ void tst_TempFile() {
   std::string filename;
   std::string contents = "hello, my name is Michael\n...\nBentley, that is.";
   {
-    fsutil::TempFile tempfile;
+    flit::TempFile tempfile;
     filename = tempfile.name;
     tempfile.out << contents;
     tempfile.out.flush();
-    TH_EQUAL(contents, fsutil::readfile(filename));
+    TH_EQUAL(contents, flit::readfile(filename));
   }
   // make sure the file has been deleted.
-  TH_THROWS(fsutil::readfile(filename), std::ios_base::failure);
+  TH_THROWS(flit::readfile(filename), std::ios_base::failure);
 }
 TH_REGISTER(tst_TempFile);
 
@@ -729,21 +724,21 @@ void tst_TempDir() {
   std::string filepath;
 
   {
-    fsutil::TempDir tmpdir;
+    flit::TempDir tmpdir;
     tmpdir_name = tmpdir.name();
-    filepath = fsutil::join(tmpdir_name, filename);
-    fsutil::touch(filepath);
-    auto listing = fsutil::listdir(tmpdir_name);
+    filepath = flit::join(tmpdir_name, filename);
+    flit::touch(filepath);
+    auto listing = flit::listdir(tmpdir_name);
     std::vector<std::string> expected_listing { filename };
     TH_EQUAL(expected_listing, listing);
-    TH_EQUAL("", fsutil::readfile(filepath));
+    TH_EQUAL("", flit::readfile(filepath));
   }
 
   // check that the directory no longer exists
-  TH_THROWS(fsutil::listdir(tmpdir_name), std::ios_base::failure);
+  TH_THROWS(flit::listdir(tmpdir_name), std::ios_base::failure);
 
   // check that the file no longer exists
-  TH_THROWS(fsutil::readfile(filepath), std::ios_base::failure);
+  TH_THROWS(flit::readfile(filepath), std::ios_base::failure);
 }
 TH_REGISTER(tst_TempDir);
 
@@ -752,15 +747,15 @@ TH_REGISTER(tst_TempDir);
 namespace tst_TinyDir {
 
 void tst_TinyDir_constructor_doesnt_exist() {
-  TH_THROWS(fsutil::TinyDir("/dir/does/not/exist"), std::ios_base::failure);
+  TH_THROWS(flit::TinyDir("/dir/does/not/exist"), std::ios_base::failure);
 }
 TH_REGISTER(tst_TinyDir_constructor_doesnt_exist);
 
 void tst_TinyDir_iterate() {
-  fsutil::TempDir tempdir;
-  fsutil::touch(fsutil::join(tempdir.name(), "file1.txt"));
-  fsutil::touch(fsutil::join(tempdir.name(), "file2.txt"));
-  fsutil::touch(fsutil::join(tempdir.name(), "file3.txt"));
+  flit::TempDir tempdir;
+  flit::touch(flit::join(tempdir.name(), "file1.txt"));
+  flit::touch(flit::join(tempdir.name(), "file2.txt"));
+  flit::touch(flit::join(tempdir.name(), "file3.txt"));
   std::vector<std::string> listing;
   std::vector<std::string> expected_listing {
     ".",
@@ -769,7 +764,7 @@ void tst_TinyDir_iterate() {
     "file2.txt",
     "file3.txt",
   };
-  fsutil::TinyDir tinydir(tempdir.name());
+  flit::TinyDir tinydir(tempdir.name());
   while (tinydir.hasnext()) {
     auto file = tinydir.readfile();
     tinydir.nextfile();
@@ -782,10 +777,10 @@ void tst_TinyDir_iterate() {
 TH_REGISTER(tst_TinyDir_iterate);
 
 void tst_TinyDir_iterator() {
-  fsutil::TempDir tempdir;
-  fsutil::touch(fsutil::join(tempdir.name(), "file1.txt"));
-  fsutil::touch(fsutil::join(tempdir.name(), "file2.txt"));
-  fsutil::touch(fsutil::join(tempdir.name(), "file3.txt"));
+  flit::TempDir tempdir;
+  flit::touch(flit::join(tempdir.name(), "file1.txt"));
+  flit::touch(flit::join(tempdir.name(), "file2.txt"));
+  flit::touch(flit::join(tempdir.name(), "file3.txt"));
   std::vector<std::string> listing;
   std::vector<std::string> expected_listing {
     ".",
@@ -794,7 +789,7 @@ void tst_TinyDir_iterator() {
     "file2.txt",
     "file3.txt",
   };
-  fsutil::TinyDir tinydir(tempdir.name());
+  flit::TinyDir tinydir(tempdir.name());
   for (auto file : tinydir) {
     listing.push_back(file.name);
   }
@@ -809,15 +804,15 @@ TH_REGISTER(tst_TinyDir_iterator);
 namespace tst_FileCloser {
 
 void tst_FileCloser() {
-  fsutil::TempDir temp_dir;
+  flit::TempDir temp_dir;
   std::string content = "hello world!";
-  std::string fname = fsutil::join(temp_dir.name(), "tmp.txt");
+  std::string fname = flit::join(temp_dir.name(), "tmp.txt");
   FILE* temp_file = fopen(fname.c_str(), "w");
   {
-    fsutil::FileCloser closer(temp_file);
+    flit::FileCloser closer(temp_file);
     fprintf(temp_file, "%s", content.c_str());
   }
-  TH_EQUAL(content, fsutil::readfile(fname));
+  TH_EQUAL(content, flit::readfile(fname));
   // Unfortunately, there is no way to check that the FILE* pointer was closed
   // without stubbing.  This is because it is undefined behavior if you use the
   // FILE* pointer in any way after fclose().
@@ -829,29 +824,29 @@ TH_REGISTER(tst_FileCloser);
 namespace tst_FdReplace {
 
 void tst_FdReplace() {
-  fsutil::FileCloser t1(tmpfile());
-  fsutil::FileCloser t2(tmpfile());
+  flit::FileCloser t1(tmpfile());
+  flit::FileCloser t2(tmpfile());
   fprintf(t1.file, "hi there");
   {
-    fsutil::FdReplace replacer(t1.file, t2.file);
+    flit::FdReplace replacer(t1.file, t2.file);
     fprintf(t1.file, "hello ");
     fflush(t1.file);
     fprintf(t2.file, "world");
     fflush(t2.file);
-    TH_EQUAL("hello world", fsutil::readfile(t1.file));
-    TH_EQUAL("hello world", fsutil::readfile(t2.file));
+    TH_EQUAL("hello world", flit::readfile(t1.file));
+    TH_EQUAL("hello world", flit::readfile(t2.file));
   }
-  TH_EQUAL("hi there", fsutil::readfile(t1.file));
-  TH_EQUAL("hello world", fsutil::readfile(t2.file));
+  TH_EQUAL("hi there", flit::readfile(t1.file));
+  TH_EQUAL("hello world", flit::readfile(t2.file));
 }
 TH_REGISTER(tst_FdReplace);
 
 void tst_FdReplace_nullptr() {
-  fsutil::FileCloser t1(tmpfile());
-  fsutil::FileCloser t2(tmpfile());
-  TH_THROWS(fsutil::FdReplace(nullptr, nullptr), std::ios_base::failure);
-  TH_THROWS(fsutil::FdReplace(t1.file, nullptr), std::ios_base::failure);
-  TH_THROWS(fsutil::FdReplace(nullptr, t1.file), std::ios_base::failure);
+  flit::FileCloser t1(tmpfile());
+  flit::FileCloser t2(tmpfile());
+  TH_THROWS(flit::FdReplace(nullptr, nullptr), std::ios_base::failure);
+  TH_THROWS(flit::FdReplace(t1.file, nullptr), std::ios_base::failure);
+  TH_THROWS(flit::FdReplace(nullptr, t1.file), std::ios_base::failure);
 }
 
 } // end of namespace tst_FdReplace
@@ -864,7 +859,7 @@ void tst_StreamBufReplace() {
   s1 << "hi there";
   TH_EQUAL(s1.str(), "hi there");
   {
-    fsutil::StreamBufReplace stream_replacer(s1, s2);
+    flit::StreamBufReplace stream_replacer(s1, s2);
     s1 << "hello ";
     TH_EQUAL(s2.str(), "hello ");
 

--- a/tests/flit_src/tst_subprocess.cpp
+++ b/tests/flit_src/tst_subprocess.cpp
@@ -89,6 +89,7 @@
 #include "subprocess.h"
 #include "flitHelpers.h"
 #include "flit.h"
+#include "fsutil.h"
 
 int main(int argCount, char* argList[]) {
   // Fast track means calling a user's main() function
@@ -235,7 +236,7 @@ void tst_register_main_duplicate_func() {
 // Therefore, we do not need to test those functions in isolation
 void tst_call_main() {
   // this is a prerequisite to calling call_main()
-  flit::g_program_path = flit::fsutil::which("./tst_subprocess");
+  flit::g_program_path = flit::which("./tst_subprocess");
 
   auto result = flit::call_main(mymains::mymain_1, "arbitrary_name",
                                 "the remaining args");


### PR DESCRIPTION
Fixes #286 

**Description:**
At first, I was simply adding some string function helpers for what Ian was doing on some tests we were developing for a client.  A few more things got done during that time.

- Added extra argument to `flit::split()` called `maxsplit`.  You can split a user-specified number of times (maximum).
- Add `flit::trim()`, `flit::rtrim()`, and `flit::ltrim()` for trimming whitespace from both sides of a `std::string`.
- Move `flit::ofopen()` and `flit::ifopen()` into `src/fsutil.h`
- Remove the namespace `flti::fsutil` since it was long and redundant.
- Add a bunch of missing documentation

**Documentation:**
I added a whole new page called `Flit Helpers` which describes all of the helper classes and functions that may be useful to test creators.

**Tests:**
Automated tests were added for `flit::split()`, `flit::ltrim()`, `flit::rtrim()`, and `flit::trim()`.  The namespace change required updating many tests to get them to pass again.