### PR TITLE
Issue289 bisect test failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,9 @@ matrix:
           packages:
             - *native_deps
 
-before_install: pip3 install --user toml $extra_pip
+before_install:
+  - pip3 install --user setuptools
+  - pip3 install --user toml $extra_pip
 
 script: make -j4 && make -j4 -C tests && make check
 

--- a/tests/flit_cli/flit_bisect/data/tests/file4.cxx
+++ b/tests/flit_cli/flit_bisect/data/tests/file4.cxx
@@ -92,6 +92,10 @@ int file4_func2() { return 2; }
 int file4_func3() { return 3; }
 int file4_func4() { return 4; }
 
+// Needs to be put into an unnamed namespace so that the symbols are local
+// instead of global and weak.  This is needed for Bisect to work properly.
+namespace {
+
 template<int i>
 int file4_func5_TEMPLATE_PROBLEM() {
   if (std::string(FLIT_OPTL) == "-O3") {
@@ -101,7 +105,7 @@ int file4_func5_TEMPLATE_PROBLEM() {
   }
 }
 
-
+} // end of unnamed namespace
 
 int file4_all() {
   return file4_func1()

--- a/tests/flit_cli/flit_bisect/tst_bisect.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect.py
@@ -189,8 +189,8 @@ Verify all non-templated functions were identified during the symbol searches
 ...             if x.startswith('    Found differing symbol on line')])))
 line 100 -- file1_func3_PROBLEM() (score 2.0)
 line 103 -- file3_func5_PROBLEM() (score 3.0)
-line 106 -- file4_all() (score 30.0)
 line 108 -- file1_func4_PROBLEM() (score 3.0)
+line 110 -- file4_all() (score 30.0)
 line 90 -- file2_func1_PROBLEM() (score 7.0)
 line 92 -- file1_func2_PROBLEM() (score 5.0)
 line 92 -- file3_func2_PROBLEM() (score 1.0)
@@ -224,7 +224,7 @@ False
 Verify the bad symbols section for file4.cxx
 >>> idx = bisect_out.index('  All differing symbols in tests/file4.cxx:')
 >>> print('\\n'.join(sorted(bisect_out[idx+1:idx+2])))
-    line 106 -- file4_all() (score 30.0)
+    line 110 -- file4_all() (score 30.0)
 >>> bisect_out[idx+2].startswith(' ')
 False
 
@@ -246,7 +246,7 @@ Test the All differing symbols section of the output
 >>> idx = bisect_out.index('All variability inducing symbols:')
 >>> print('\\n'.join(bisect_out[idx+1:])) # doctest:+ELLIPSIS
   tests/BisectTest.cpp:96 ... -- real_problem_test(int, char**) (score 50.0)
-  tests/file4.cxx:106 ... -- file4_all() (score 30.0)
+  tests/file4.cxx:110 ... -- file4_all() (score 30.0)
   tests/file2.cpp:90 ... -- file2_func1_PROBLEM() (score 7.0)
   tests/file1.cpp:92 ... -- file1_func2_PROBLEM() (score 5.0)
   tests/file1.cpp:108 ... -- file1_func4_PROBLEM() (score 3.0)

--- a/tests/flit_mpi/data/MpiHello.cpp
+++ b/tests/flit_mpi/data/MpiHello.cpp
@@ -85,10 +85,12 @@
 
 #include <mpi.h>
 
+#include <iostream>
 #include <string>
 #include <sstream>
 
 #include <cstring>
+#include <cstdio>
 
 // this is the real test, run under MPI in separate processes
 int mpi_main(int argCount, char* argList[]) {
@@ -99,27 +101,35 @@ int mpi_main(int argCount, char* argList[]) {
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-  std::cout << std::endl;
-  std::cout << "hello from rank " << rank << " of " << world_size << std::endl;
-  std::cout << "mpi_main(" << argCount << ", {";
+  std::ostringstream buffer;
+
+  printf("\n");
+  printf("hello from rank %d of %d\n", rank, world_size);
+  std::fflush(stdout);
+
+  buffer << "mpi_main(" << argCount << ", {";
   bool first = true;
   for (int i = 0; i < argCount; i++) {
-    if (!first) { std::cout << ", "; }
+    if (!first) { buffer << ", "; }
     first = false;
-    std::cout << argList[i];
+    buffer << argList[i];
   }
-  std::cout << "})\n";
+  buffer << "})\n";
+  printf("%s", buffer.str().c_str());
+  std::fflush(stdout);
 
   // send a message from rank 0 to rank 1
   if (rank == 0) {
     char message[13];
     strcpy(message, "hello world!");
     MPI_Send(message, 13, MPI_BYTE, 1, 0, MPI_COMM_WORLD);
-    std::cout << "Sending '" << message << "' from rank 0\n";
+    printf("Sending '%s' from rank 0\n", message);
+    std::fflush(stdout);
   } else if (rank == 1) {
-    char buffer[13];
-    MPI_Recv(buffer, 13, MPI_BYTE, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-    std::cout << "Received '" << buffer << "' from rank 0 to rank 1\n";
+    char message[13];
+    MPI_Recv(message, 13, MPI_BYTE, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    printf("Received '%s' from rank 0 to rank 1\n", message);
+    std::fflush(stdout);
   } else {
     throw std::logic_error("there should only be two ranks");
   }


### PR DESCRIPTION
Fixes #289 

**Description:**
One of the test files used in `tst_bisect.py` called `file4.cxx` uses a template function.  Unfortunately, the template function gets compiled as global weak symbols.  We intended for it to be inlined, which is not guaranteed.  As weak global symbols, they can be overridden with symbols from the other object file.  This simply wasn't happening before and for some unknown reason, it is now happening.

Instead, we want it to be local symbols instead of global symbols when it is not inlined.  To solve this, I placed the template function within an unnamed namespace.  Another solution could have been to mark the function as static.

The other thing necessary was to install `setuptools` before installing `toml` with pip.  I think this is because either toml was updated or pip is really old on this system.

**Documentation:**
No document change necessary.  Just getting things to work as expected.

**Tests:**
Fixed `tests/flit_cli/flit_bisect/tst_bisect.py`.