### PR TITLE
Put InfoStream into flit namespace

### DIFF
--- a/src/InfoStream.cpp
+++ b/src/InfoStream.cpp
@@ -106,6 +106,8 @@ namespace {
   std::mutex infoStreamMutex;
 } // end of unnamed namespace
 
+namespace flit {
+
 InfoStream::InfoStream()
   : std::ostream()
   , _threadbuf()
@@ -135,3 +137,4 @@ void InfoStream::flushout() {
   _threadbuf.str("");
 }
 
+} // end of namespace flit

--- a/src/InfoStream.h
+++ b/src/InfoStream.h
@@ -87,6 +87,8 @@
 #include <sstream>
 #include <iostream>
 
+namespace flit {
+
 class InfoStream : public std::ostream {
 public:
   InfoStream();
@@ -100,5 +102,6 @@ private:
   std::ostringstream _threadbuf;
 };
 
-#endif // INFO_STREAM_H
+} //end of namespace flit
 
+#endif // INFO_STREAM_H


### PR DESCRIPTION
Fixes #96

**Description:**
For consistency, we want everything in FLiT to be in the `flit` namespace.  I checked and there was only one thing not in the `flit` namespace and that was the `InfoStream` class.  This change only moves the `InfoStream` into the FLiT namespace.

**Documentation:**
None needed.  It is already documented as being in the `flit` namespace

**Tests:**
No additional tests needed, just ensured that all existing tests are still working.