### PR TITLE
Issue227 remove hostname

### DIFF
--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -383,7 +383,7 @@ ifeq ($(R_TYPE),dirs)
 ALL_DIRS += $(foreach c,$(COMPILERS),\
               $(foreach s,$(SWITCHES_$(strip $c)),\
                 $(foreach o,$(OPCODES_$(strip $c)),\
-                  $(OBJ_DIR)/$c_$(HOSTNAME)_$s_$o)))
+                  $(OBJ_DIR)/$c_$s_$o)))
 
 ifeq ($(UNAME_S),Darwin)
 ALL_DIRS += lib
@@ -405,15 +405,15 @@ else ifeq ($(R_TYPE),runbuild)
 # @param 2: switches variable name
 # @param 3: optl variable name
 define RUNBUILD_REC_RULE
-recursion-target: $(RUNBUILD_DIR)/$1_$(HOSTNAME)_$2_$3
+recursion-target: $(RUNBUILD_DIR)/$1_$2_$3
 $(eval $(call REC_COMPILE_RULE,\
-  $(RUNBUILD_DIR)/$1_$(HOSTNAME)_$2_$3,\
+  $(RUNBUILD_DIR)/$1_$2_$3,\
   $($1),\
   $($3),\
   $($2),\
   $($1_CXXFLAGS),\
   $($1_LDFLAGS),\
-  $(OBJ_DIR)/$1_$(HOSTNAME)_$2_$3))
+  $(OBJ_DIR)/$1_$2_$3))
 endef
 
 $(foreach c,$(COMPILERS),\
@@ -434,7 +434,7 @@ else ifeq ($(R_TYPE),run)
 ALL_RESULTS := $(foreach c,$(COMPILERS),\
                  $(foreach s,$(SWITCHES_$(strip $c)),\
                    $(foreach o,$(OPCODES_$(strip $c)),\
-                     $(RESULTS_DIR)/$c_$(HOSTNAME)_$s_$o-out-comparison.csv)))
+                     $(RESULTS_DIR)/$c_$s_$o-out-comparison.csv)))
 
 recursion-target: $(ALL_RESULTS)
 

--- a/documentation/flit-configuration-file.md
+++ b/documentation/flit-configuration-file.md
@@ -22,7 +22,6 @@ used._
 
 ```toml
 [host]
-name = 'my.hostname.com'
 flit_path = '/usr/bin/flit'
 config_dir = '/usr/share/flit/config'
 ```
@@ -30,7 +29,6 @@ config_dir = '/usr/share/flit/config'
 When you initialize your project with `flit init`, these fields will be
 populated with values corresponding to the values on your machine:
 
-- `name`: hostname of the current machine
 - `flit_path`: will be initialized to the path of the `flit.py` script or its
   symbolic link
 - `config_dir`: directory containing default configuration values.  Either the
@@ -309,7 +307,6 @@ default) configuration file:
 
 ```toml
 [host]
-name = 'my.hostname.com'
 flit_path = '/usr/bin/flit'
 config_dir = '/usr/share/flit/config'
 

--- a/scripts/flitcli/config/flit-default.toml.in
+++ b/scripts/flitcli/config/flit-default.toml.in
@@ -85,9 +85,6 @@
 # General information
 [host]
 
-# if you omit name, the system hostname will be used
-name = '{hostname}'
-
 # if you omit flit_path, the current flit executable will be used
 flit_path = '{flit_path}'
 

--- a/scripts/flitcli/experimental/flit_ninja.py
+++ b/scripts/flitcli/experimental/flit_ninja.py
@@ -369,8 +369,6 @@ class NinjaWriter:
         self.ninja_gen_deps.append(tomlfile)
         projconf = util.load_projconf()
 
-        self.hostname = projconf['host']['name']
-
         if projconf['run']['enable_mpi']:
             mpi_cxxflags, mpi_ldflags = flit_update.get_mpi_flags()
             self.cxxflags.extend(mpi_cxxflags)

--- a/scripts/flitcli/flitutil.py
+++ b/scripts/flitcli/flitutil.py
@@ -112,7 +112,6 @@ def get_default_toml_string():
             {
                 'flit_path': os.path.join(conf.script_dir, 'flit.py'),
                 'config_dir': conf.config_dir,
-                'hostname': socket.gethostname(),
                 'flit_version': conf.version,
             })
     return _default_toml_string


### PR DESCRIPTION
Fixes #227 

**Description:**
Remove use of hostname from runs.

- Remove hostname as part of the executable names
- Remove `host/name` from `flit-config.toml`

The hostname is not entirely removed

- Still define `FLIT_HOSTNAME` when compiling object files
- Still store it in the database
- Still store the hostname into the `HOSTNAME` variable in the `Makefile`

As implemented, not a big breaking change.  It would just require recompiling your tests after cleaning.

**Documentation:**
Just remove references to `host/name` in `flit-config.toml`

**Tests:**
No changes to tests were necessary.  They all pass still.