### PR TITLE
Issue133 nan compare

### DIFF
--- a/data/tests/Empty.cpp
+++ b/data/tests/Empty.cpp
@@ -132,8 +132,8 @@ public:
    */
   virtual long double compare(long double ground_truth,
                               long double test_results) const override {
-    // absolute error
-    return std::abs(test_results - ground_truth);
+    // absolute error with NaN and inf support
+    return flit::abs_compare(ground_truth, test_results);
   }
 
   /** There is no good default implementation comparing two strings */

--- a/documentation/writing-test-cases.md
+++ b/documentation/writing-test-cases.md
@@ -78,35 +78,15 @@ like to override that behavior.
 The `flit::abs_compare()` function used as the default implementation for
 `compare(long double ground_truth, long double test_value)` does more than just
 `std::abs(test_value - ground_truth)`.  It handles `NaN` and `inf` in a special
-way according to the following table:
+way.  The table below has only the instances where the behavior of
+`flit::abs_compare()` is different from `std::abs()`:
 
-| ground truth| test value | Return | Why?                          |
-|-------------|------------|--------|-------------------------------|
-|  NaN        |  NaN       |  0.0   | Match                         |
-|  NaN        | -NaN       |  NaN   | Do not match                  |
-|  NaN        |  inf       |  inf   | To be different than `-NaN`   |
-|  NaN        | -inf       |  inf   | To be different than `-NaN`   |
-|  NaN        |  normal    |  NaN   | Only thing that makes sense   |
-| -NaN        |  NaN       |  NaN   | Do not match                  |
-| -NaN        | -NaN       |  0.0   | Match                         |
-| -NaN        |  inf       |  inf   | To be different than `NaN`    |
-| -NaN        | -inf       |  inf   | To be different than `NaN`    |
-| -NaN        |  normal    |  NaN   | Only thing that makes sense   |
-|  inf        |  NaN       |  NaN   | To be different than `-inf`   |
-|  inf        | -NaN       |  NaN   | To be different than `-inf`   |
-|  inf        |  inf       |  0.0   | Match                         |
-|  inf        | -inf       |  inf   | Do not match                  |
-|  inf        |  normal    |  inf   | Only thing that makes sense   |
-| -inf        |  NaN       |  NaN   | To be different than `inf`    |
-| -inf        | -NaN       |  NaN   | To be different than `inf`    |
-| -inf        |  inf       |  inf   | Do not match                  |
-| -inf        | -inf       |  0.0   | Match                         |
-| -inf        |  normal    |  inf   | Only thing that makes sense   |
-|  normal     |  NaN       |  NaN   | Regular `std::abs()` behavior |
-|  normal     | -NaN       |  NaN   | Regular `std::abs()` behavior |
-|  normal     |  inf       |  inf   | Regular `std::abs()` behavior |
-|  normal     | -inf       |  inf   | Regular `std::abs()` behavior |
-|  normal     |  normal    |  abs   | Regular `std::abs()` behavior |
+| ground truth| test value | Return |
+|-------------|------------|--------|
+|  NaN        |  NaN       |  0.0   |
+| -NaN        | -NaN       |  0.0   |
+|  inf        |  inf       |  0.0   |
+| -inf        | -inf       |  0.0   |
 
 The differences from using the regular `std::abs()` is that
 
@@ -114,10 +94,6 @@ The differences from using the regular `std::abs()` is that
   then return `0.0`.  If the value from the ground truth is `NaN`, then we
   return `0.0` if the test value is also `NaN` to signify that we got the
   expected value.
-* If the ground truth is `NaN` and the test value is `inf`, then return `inf`
-  (ignoring sign).  This is to signify that we got an unexpected value of `inf`
-  instead of `NaN`, since a test value of `-NaN` would result in an output of
-  `NaN`.
 
 The `flit::l2norm()` function uses the `flit::abs_compare()` function to take
 the difference element-wise between the two vectors before doing summation.

--- a/src/flit/TestBase.h
+++ b/src/flit/TestBase.h
@@ -363,7 +363,7 @@ public:
   virtual long double compare(long double ground_truth,
                               long double test_results) const {
     // absolute error
-    return std::abs(test_results - ground_truth);
+    return flit::abs_compare(ground_truth, test_results);
   }
 
   /** There is no good default implementation comparing two strings */

--- a/src/flit/flit.cpp
+++ b/src/flit/flit.cpp
@@ -452,7 +452,6 @@ std::vector<TestResult> parseResults(std::istream &in) {
   std::vector<TestResult> results;
 
   CsvReader reader(in);
-  CsvRow row;
   for (CsvRow row; reader >> row; ) {
     auto nanosec = std::stol(row["nanosec"]);
     Variant value;

--- a/src/flit/flitHelpers.h
+++ b/src/flit/flitHelpers.h
@@ -282,7 +282,6 @@ bool equal_with_nan_inf(T a, T b) {
  * The main difference is
  * - If actual is the exact same as expected, then return 0.0.
  *   That includes NaN, -NaN, inf, and -inf
- * - If expected is NaN and actual is inf, return inf
  */
 template <typename T>
 T abs_compare(T expected, T actual) {

--- a/src/flit/flitHelpers.h
+++ b/src/flit/flitHelpers.h
@@ -254,6 +254,22 @@ as_int(long double val) {
   return temp & (~zero >> 48);
 }
 
+/**
+ * Default comparison used by FLiT.  Similar to
+ *
+ *   abs(actual - expected)
+ *
+ * The main difference is
+ * - If actual is the exact same as expected, then return 0.0.
+ *   That includes NaN, -NaN, inf, and -inf
+ * - If expected is NaN and actual is inf, return inf
+ */
+template <typename T>
+T abs_compare(T expected, T actual) {
+  // TODO: implement all other cases
+  return std::abs(actual - expected);
+}
+
 template <typename T>
 long double l2norm(const std::vector<T> &v1, const std::vector<T> &v2) {
   static_assert(std::is_floating_point<T>::value,
@@ -261,7 +277,7 @@ long double l2norm(const std::vector<T> &v1, const std::vector<T> &v2) {
   long double score = 0.0L;
   int len = std::min(v1.size(), v2.size());
   for (int i = 0; i < len; i++) {
-    T diff = v1[i] - v2[i];
+    T diff = abs_compare(v1[i], v2[i]);
     score += diff * diff;
   }
   // remaining elements

--- a/src/flit/flitHelpers.h
+++ b/src/flit/flitHelpers.h
@@ -289,9 +289,6 @@ T abs_compare(T expected, T actual) {
   if (equal_with_nan_inf(expected, actual)) {
     return T(0.0);
   }
-  if (std::isnan(expected) && std::isinf(actual)) {
-    return std::numeric_limits<T>::infinity();
-  }
   return std::abs(actual - expected);
 }
 

--- a/tests/flit_cli/flit_bisect/data/tests/BisectTest.cpp
+++ b/tests/flit_cli/flit_bisect/data/tests/BisectTest.cpp
@@ -115,7 +115,7 @@ public:
   virtual std::vector<T> getDefaultInput() override { return {}; }
   virtual long double compare(long double ground_truth,
                               long double test_results) const override {
-    return std::abs(test_results - ground_truth);
+    return flit::abs_compare(ground_truth, test_results);
   }
 
 protected:

--- a/tests/flit_src/tst_flitHelpers_h.cpp
+++ b/tests/flit_src/tst_flitHelpers_h.cpp
@@ -281,31 +281,13 @@ TH_TEST(tst_as_int_128bit) {
 namespace tst_abs_compare {
 
 template <typename T>
-bool equal_with_nan_inf(T a, T b) {
-  if (std::fpclassify(a) == std::fpclassify(b)) {
-    switch (std::fpclassify(a)) {
-      case FP_INFINITE:
-      case FP_NAN:
-        return std::signbit(a) == std::signbit(b);
-
-      case FP_NORMAL:
-      case FP_SUBNORMAL:
-      case FP_ZERO:
-      default:
-        return a == b;
-    }
-  }
-  return false;
-}
-
-template <typename T>
 void tst_equal_with_nan_inf_impl() {
   using lim = std::numeric_limits<T>;
 
   static_assert(lim::has_quiet_NaN);
   static_assert(lim::has_infinity);
 
-  auto eq = equal_with_nan_inf<T>;
+  auto &eq = flit::equal_with_nan_inf<T>;
   T my_nan = lim::quiet_NaN();
   T my_inf = lim::infinity();
   T normal = -3.2;
@@ -370,8 +352,8 @@ void tst_abs_compare_impl() {
   T normal = -3.2;
   T zero = 0.0;
 
-  auto eq = equal_with_nan_inf<T>;
-  auto comp = flit::abs_compare<T>;
+  auto &eq = flit::equal_with_nan_inf<T>;
+  auto &comp = flit::abs_compare<T>;
 
   // we have 25 cases
   TH_VERIFY(eq(comp( my_nan,  my_nan),   zero ));

--- a/tests/flit_src/tst_flitHelpers_h.cpp
+++ b/tests/flit_src/tst_flitHelpers_h.cpp
@@ -284,8 +284,8 @@ template <typename T>
 void tst_equal_with_nan_inf_impl() {
   using lim = std::numeric_limits<T>;
 
-  static_assert(lim::has_quiet_NaN);
-  static_assert(lim::has_infinity);
+  static_assert(lim::has_quiet_NaN, "Type T does not have quiet NaNs");
+  static_assert(lim::has_infinity,  "Type T does not have infinity");
 
   auto &eq = flit::equal_with_nan_inf<T>;
   T my_nan = lim::quiet_NaN();
@@ -345,8 +345,8 @@ TH_TEST(tst_equal_with_nan_inf) {
 template<typename T>
 void tst_abs_compare_impl() {
   using lim = std::numeric_limits<T>;
-  static_assert(lim::has_quiet_NaN);
-  static_assert(lim::has_infinity);
+  static_assert(lim::has_quiet_NaN, "Type T does not have quiet NaNs");
+  static_assert(lim::has_infinity,  "Type T does not have infinity");
   T my_nan = lim::quiet_NaN();
   T my_inf = lim::infinity();
   T normal = -3.2;

--- a/tests/flit_src/tst_flitHelpers_h.cpp
+++ b/tests/flit_src/tst_flitHelpers_h.cpp
@@ -358,14 +358,14 @@ void tst_abs_compare_impl() {
   // we have 25 cases
   TH_VERIFY(eq(comp( my_nan,  my_nan),   zero ));
   TH_VERIFY(eq(comp( my_nan, -my_nan),  my_nan));
-  TH_VERIFY(eq(comp( my_nan,  my_inf),  my_inf));
-  TH_VERIFY(eq(comp( my_nan, -my_inf),  my_inf));
+  TH_VERIFY(eq(comp( my_nan,  my_inf),  my_nan));
+  TH_VERIFY(eq(comp( my_nan, -my_inf),  my_nan));
   TH_VERIFY(eq(comp( my_nan,  normal),  my_nan));
 
   TH_VERIFY(eq(comp(-my_nan,  my_nan),  my_nan));
   TH_VERIFY(eq(comp(-my_nan, -my_nan),   zero ));
-  TH_VERIFY(eq(comp(-my_nan,  my_inf),  my_inf));
-  TH_VERIFY(eq(comp(-my_nan, -my_inf),  my_inf));
+  TH_VERIFY(eq(comp(-my_nan,  my_inf),  my_nan));
+  TH_VERIFY(eq(comp(-my_nan, -my_inf),  my_nan));
   TH_VERIFY(eq(comp(-my_nan,  normal),  my_nan));
 
   TH_VERIFY(eq(comp( my_inf,  my_nan),  my_nan));
@@ -395,7 +395,9 @@ TH_TEST(tst_abs_compare) {
 
 } // end of namespace tst_abs_compare
 
-TH_TEST(tst_l2norm) {
+namespace tst_l2norm {
+
+TH_TEST(tst_l2norm_normal_numbers) {
   std::vector<float> empty;
   std::vector<float> one_elem { 1.0L };
   std::vector<float> two_elems { 3.5L, 1.0L };
@@ -410,6 +412,27 @@ TH_TEST(tst_l2norm) {
   TH_EQUAL(flit::l2norm(one_elem , two_elems),  7.25L);
   TH_EQUAL(flit::l2norm(two_elems, two_elems),  0.0L );
 }
+
+TH_TEST(tst_l2norm_nan_and_inf) {
+  using lim = std::numeric_limits<float>;
+  float my_nan = lim::quiet_NaN();
+  float my_inf = lim::infinity();
+
+  auto &eq = flit::equal_with_nan_inf<long double>;
+
+  std::vector<float> nans  { my_nan, -my_nan, my_nan};
+  std::vector<float> nans2 {-my_nan, -my_nan, my_nan}; // mismatching in val 0
+  std::vector<float> infs  { my_inf, -my_inf, my_inf};
+  std::vector<float> infs2 { my_inf,  my_inf, my_inf}; // mismatching in val 1
+
+  TH_VERIFY(eq(flit::l2norm(nans, nans ),  0.0L ));
+  TH_VERIFY(eq(flit::l2norm(nans, nans2), my_nan));
+  TH_VERIFY(eq(flit::l2norm(infs, infs ),  0.0L ));
+  TH_VERIFY(eq(flit::l2norm(infs, infs2), my_inf));
+  TH_VERIFY(eq(flit::l2norm(nans, infs ), my_nan));
+}
+
+} // end of namespace tst_l2norm
 
 namespace tst_split {
 


### PR DESCRIPTION
Fixes #133 

**Description:**
I created a new function called `flit::abs_compare(a, b)` that does a little more than `std::abs(a-b)`.

- If `a` and `b` are both `NaN` with the same sign, return `0.0`
- If `a` and `b` are both `inf` with the same sign, return `0.0`

This is to be a better default comparison function that will not fail if both test and baseline values match (even if they are `inf` or `NaN`).

This `flit::abs_compare()` function is used also from `flit::l2norm()` to take the difference between elements before taking the square and summing.  Therefore, `flit::l2norm()` also benefits from being able to handle `inf` and `NaN` in matching spots within the vector.

I changed `data/tests/Empty.cpp` to use `flit::abs_compare()` as the default comparison between `long double` values.

**Documentation:**
Added a section in `writing-test-cases.md` called `Default Comparison Details` giving these details for both `flit::abs_compare()` and `flit::l2norm()`.

**Tests:**
Added tests to `tests/flit_src/tst_flitHelpers_h.cpp` for `flit::abs_compare()`, and made more tests for `flit::l2norm()`.